### PR TITLE
Chaning declarations to DocumentSymbol

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -145,10 +145,7 @@ export class MetaModelicaServer {
    * @param params  Unused.
    * @returns       Symbol information.
    */
-  private onDocumentSymbol(params: LSP.DocumentSymbolParams): LSP.SymbolInformation[] {
-    // TODO: ideally this should return LSP.DocumentSymbol[] instead of LSP.SymbolInformation[]
-    // which is a hierarchy of symbols.
-    // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentSymbol
+  private onDocumentSymbol(params: LSP.DocumentSymbolParams): LSP.DocumentSymbol[] {
     logger.debug(`onDocumentSymbol`);
     return this.analyzer.getDeclarationsForUri(params.textDocument.uri);
   }

--- a/server/src/util/test/util.test.ts
+++ b/server/src/util/test/util.test.ts
@@ -35,6 +35,7 @@
 
 import * as assert from 'assert';
 
+import { MetaModelicaQueries } from '../../analyzer';
 import { initializeParser } from '../../parser';
 import * as TreeSitterUtil from '../tree-sitter';
 
@@ -43,7 +44,8 @@ describe('getIdentifier', () => {
     const parser = await initializeParser();
     const tree = parser.parse("type Temperature = Real(unit = \"K \");");
     const classNode = tree.rootNode.childForFieldName("classDefinitionList")!;
-    const name = TreeSitterUtil.getIdentifier(classNode);
+    const queries = new MetaModelicaQueries(parser.getLanguage());
+    const name = queries.getIdentifier(classNode);
 
     assert.equal(name, 'Temperature');
   });

--- a/server/src/util/tree-sitter.ts
+++ b/server/src/util/tree-sitter.ts
@@ -140,17 +140,6 @@ export function findParent(
 }
 
 /**
- * Get identifier from node.
- *
- * @param start   Syntax tree node.
- */
-export function getIdentifier(start: SyntaxNode): string | undefined {
-
-  const node = findFirst(start, (n: SyntaxNode) => n.type == 'IDENT');
-  return node?.text;
-}
-
-/**
  * Get class type from `class_definition` node.
  *
  * @param node  Class definition node.


### PR DESCRIPTION
Changing declarations for outline from `LSP.SymbolInformation` to `LSP.DocumentSymbol`.

Using queries for getting information from tree instead of parsing strings.