### PR TITLE
[Server] Detect unused match/matchcontinue arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ out/
 dist/
 tree-sitter-metamodelica.wasm
 tree-sitter-gdbmi.wasm
+.devcontainer/claude

--- a/README.md
+++ b/README.md
@@ -14,20 +14,20 @@ in addition.
 This Language Server works for MetaModelica files. It has the following language
 features:
 
-  - Provide Outline of MetaModelica files.
+- Provide Outline of MetaModelica files.
 
-    ![Outline](images/outline_demo.png)
+  ![Outline](images/outline_demo.png)
 
-  - Diagnostics:
+- Diagnostics:
 
-    ![Diagnostics](images/problemMatching.png)
+  ![Diagnostics](images/problemMatching.png)
 
 ## Installation
 
 ### Via Marketplace
 
-  - [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=OpenModelica.metamodelica-language-server)
-  - [Open VSX Registry](https://open-vsx.org/extension/OpenModelica/metamodelica-language-server)
+- [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=OpenModelica.metamodelica-language-server)
+- [Open VSX Registry](https://open-vsx.org/extension/OpenModelica/metamodelica-language-server)
 
 ### Via VSIX File
 
@@ -67,28 +67,28 @@ Found a bug or having issues? Open a
 
 ### Dependencies
 
-  - Docker installed and running.
+- Docker installed and running.
 
 ### Quick install
 
-  - Run `npm install` and `npm run postinstall` in this folder.This installs all
-    necessary npm modules in both the client and server folder
-  - Open VS Code on this folder.
-  - Press Ctrl+Shift+B to start compiling the client and server.
-  - Switch to the Run and Debug View in the Sidebar (Ctrl+Shift+D).
-  - Select `Launch Client` from the drop down (if it is not already).
-  - Press ▷ to run the launch config (F5).
-  - Both build task and launch are available in [watch
-    mode](https://code.visualstudio.com/docs/editor/tasks#:~:text=The%20first%20entry%20executes,the%20HelloWorld.js%20file.)
-  - In the [Extension Development
-    Host](https://code.visualstudio.com/api/get-started/your-first-extension#:~:text=Then%2C%20inside%20the%20editor%2C%20press%20F5.%20This%20will%20compile%20and%20run%20the%20extension%20in%20a%20new%20Extension%20Development%20Host%20window.)
-    instance of VSCode, open a document in 'metamodelica' language mode.
-    - Check the console output of `MetaModelica Language Server` to see the parsed
-      tree of the opened file.
+- Run `npm install` and `npm run postinstall` in this folder.This installs all
+  necessary npm modules in both the client and server folder
+- Open VS Code on this folder.
+- Press Ctrl+Shift+B to start compiling the client and server.
+- Switch to the Run and Debug View in the Sidebar (Ctrl+Shift+D).
+- Select `Launch Client` from the drop down (if it is not already).
+- Press ▷ to run the launch config (F5).
+- Both build task and launch are available in [watch
+  mode](https://code.visualstudio.com/docs/editor/tasks#:~:text=The%20first%20entry%20executes,the%20HelloWorld.js%20file.)
+- In the [Extension Development
+  Host](https://code.visualstudio.com/api/get-started/your-first-extension#:~:text=Then%2C%20inside%20the%20editor%2C%20press%20F5.%20This%20will%20compile%20and%20run%20the%20extension%20in%20a%20new%20Extension%20Development%20Host%20window.)
+  instance of VSCode, open a document in 'metamodelica' language mode.
+  - Check the console output of `MetaModelica Language Server` to see the parsed
+    tree of the opened file.
 
 ## Build and Install Extension
 
-```
+```bash
 npx vsce package
 ```
 

--- a/src/server/diagnostics.ts
+++ b/src/server/diagnostics.ts
@@ -40,6 +40,116 @@ import { MetaModelicaQueries } from './analyzer';
 import * as TreeSitterUtil from './tree-sitter';
 import { logger } from '../util/logger';
 
+export interface UnusedArgFix {
+  argName: string;
+  edits: LSP.TextEdit[];
+}
+
+/**
+ * Extract tuple element expressions from a `(a, b, c)` expression node.
+ * Returns null if the expression is not a parenthesized tuple with at least two elements.
+ */
+function getTupleInfo(expr: Parser.SyntaxNode): { inner: Parser.SyntaxNode; elements: Parser.SyntaxNode[] } | null {
+  // A tuple expression `(a, b, c)` parses as:
+  //   expression -> simple_expression -> LPAR expression COMMA expression ... RPAR
+  const inner = expr.namedChildren.find(c => c.type === 'simple_expression');
+  if (!inner) { return null; }
+
+  const hasParens = inner.children.some(c => c.type === 'LPAR') &&
+                    inner.children.some(c => c.type === 'RPAR');
+  if (!hasParens) { return null; }
+
+  const elements = inner.namedChildren.filter(c => c.type === 'expression');
+  if (elements.length < 2) { return null; }
+
+  return { inner, elements };
+}
+
+/**
+ * Return true if the expression node is a plain identifier (no dots, no call).
+ * Only plain identifiers are safe to flag as unused — complex expressions such
+ * as function calls (`f(x)`) or qualified names (`Foo.bar`) must not be removed
+ * because they may carry information or have side-effects.
+ */
+function isSimpleIdentifier(node: Parser.SyntaxNode): boolean {
+  // expression → simple_expression → component_reference__function_call → component_reference → IDENT
+  const se = node.namedChildren.find(c => c.type === 'simple_expression');
+  if (!se || se.namedChildren.length !== 1) { return false; }
+  const crf = se.namedChildren[0];
+  if (crf.type !== 'component_reference__function_call' || crf.namedChildren.length !== 1) { return false; }
+  const cr = crf.namedChildren[0];
+  if (cr.type !== 'component_reference' || cr.namedChildren.length !== 1) { return false; }
+  return cr.namedChildren[0].type === 'IDENT';
+}
+
+/**
+ * Build replacement text for a tuple after removing one element.
+ * With one element remaining the outer parentheses are dropped.
+ */
+function buildTupleNewText(elements: Parser.SyntaxNode[], skipIndex: number): string {
+  const remaining = elements.filter((_, i) => i !== skipIndex).map(e => e.text);
+  if (remaining.length === 1) { return remaining[0]; }
+  return '(' + remaining.join(', ') + ')';
+}
+
+/**
+ * Find arguments of a `match`/`matchcontinue` that are a plain identifier and
+ * matched by `_` in every case branch, and are therefore unused.
+ */
+function getUnusedMatchArguments(rootNode: Parser.SyntaxNode): { argNode: Parser.SyntaxNode; fix: UnusedArgFix }[] {
+  const results: { argNode: Parser.SyntaxNode; fix: UnusedArgFix }[] = [];
+
+  TreeSitterUtil.forEach(rootNode, (node) => {
+    if (node.type !== 'match_expression') {
+      return true;
+    }
+
+    const inputExpr = node.namedChildren.find(c => c.type === 'expression');
+    if (!inputExpr) { return true; }
+
+    const inputInfo = getTupleInfo(inputExpr);
+    if (!inputInfo) { return true; }
+
+    const { inner: inputInner, elements: inputArgs } = inputInfo;
+
+    const casesNode = node.namedChildren.find(c => c.type === 'cases');
+    if (!casesNode) { return true; }
+
+    const onecases = casesNode.namedChildren.filter(c => c.type === 'onecase');
+    if (onecases.length === 0) { return true; }
+
+    const caseInfos: { inner: Parser.SyntaxNode; elements: Parser.SyntaxNode[] }[] = [];
+    for (const onecase of onecases) {
+      const patternExpr = onecase.namedChildren.find(c => c.type === 'expression');
+      if (!patternExpr) { return true; }
+      const info = getTupleInfo(patternExpr);
+      if (!info || info.elements.length !== inputArgs.length) {
+        // Pattern arity differs; per-position usage cannot be inferred.
+        return true;
+      }
+      caseInfos.push(info);
+    }
+
+    for (let i = 0; i < inputArgs.length; i++) {
+      if (!isSimpleIdentifier(inputArgs[i])) { continue; }
+      if (caseInfos.every(ci => ci.elements[i].text.trim() === '_')) {
+        const edits: LSP.TextEdit[] = [
+          { range: TreeSitterUtil.range(inputInner), newText: buildTupleNewText(inputArgs, i) },
+          ...caseInfos.map(ci => ({
+            range: TreeSitterUtil.range(ci.inner),
+            newText: buildTupleNewText(ci.elements, i)
+          }))
+        ];
+        results.push({ argNode: inputArgs[i], fix: { argName: inputArgs[i].text, edits } });
+      }
+    }
+
+    return true;
+  });
+
+  return results;
+}
+
 export function getDiagnosticsFromTree(tree: Parser.Tree, queries: MetaModelicaQueries): LSP.Diagnostic[] {
   const diagnostics: LSP.Diagnostic[] = [];
   let captures: Parser.QueryCapture[];
@@ -116,6 +226,17 @@ export function getDiagnosticsFromTree(tree: Parser.Tree, queries: MetaModelicaQ
         LSP.DiagnosticSeverity.Information,
         "'matchcontinue' is inefficient, use 'match' and 'try-catch' instead."));
     }
+  }
+
+  // Inform about unused match/matchcontinue arguments
+  const unusedArgs = getUnusedMatchArguments(tree.rootNode);
+  for (const { argNode, fix } of unusedArgs) {
+    const diagnostic = nodeToDiagnostic(
+      argNode,
+      LSP.DiagnosticSeverity.Information,
+      `Unused match argument '${argNode.text}': pattern is '_' in every case.`);
+    (diagnostic as LSP.Diagnostic & { data: unknown }).data = { unusedArgFix: fix };
+    diagnostics.push(diagnostic);
   }
 
   // Check start and end identifier matching

--- a/src/server/extension.ts
+++ b/src/server/extension.ts
@@ -45,6 +45,7 @@ import { TextDocument} from 'vscode-languageserver-textdocument';
 import { initializeMetaModelicaParser } from './metaModelicaParser';
 import Analyzer from './analyzer';
 import { logger, setLogConnection, setLogLevel } from '../util/logger';
+import { UnusedArgFix } from './diagnostics';
 
 /**
  * MetaModelicaServer collection all the important bits and bobs.
@@ -90,6 +91,7 @@ export class MetaModelicaServer {
       documentSymbolProvider: true,
       colorProvider: false,
       semanticTokensProvider: undefined,
+      codeActionProvider: true,
       //diagnosticProvider: {
       //  interFileDependencies: false,
       //  workspaceDiagnostics: false
@@ -107,6 +109,7 @@ export class MetaModelicaServer {
     this.documents.listen(this.connection);
 
     connection.onDocumentSymbol(this.onDocumentSymbol.bind(this));
+    connection.onCodeAction(this.onCodeAction.bind(this));
 
     connection.onInitialized(async () => {
       initialized = true;
@@ -142,6 +145,31 @@ export class MetaModelicaServer {
     const diagnostics = this.analyzer.analyze(document);
 
     this.connection.sendDiagnostics({uri, diagnostics});
+  }
+
+  /**
+   * Provide quick-fix code actions for diagnostics that carry fix data.
+   */
+  private onCodeAction(params: LSP.CodeActionParams): LSP.CodeAction[] {
+    const actions: LSP.CodeAction[] = [];
+    for (const diagnostic of params.context.diagnostics) {
+      const data = diagnostic.data as { unusedArgFix?: UnusedArgFix } | undefined;
+      if (data?.unusedArgFix) {
+        const fix = data.unusedArgFix;
+        actions.push({
+          title: `Remove unused argument '${fix.argName}'`,
+          kind: LSP.CodeActionKind.QuickFix,
+          diagnostics: [diagnostic],
+          isPreferred: true,
+          edit: {
+            changes: {
+              [params.textDocument.uri]: fix.edits
+            }
+          }
+        });
+      }
+    }
+    return actions;
   }
 
   /**

--- a/test/server/diagnostics.test.ts
+++ b/test/server/diagnostics.test.ts
@@ -175,6 +175,45 @@ const expectedDiagnostics: LSP.Diagnostic[] = [
   }
 ];
 
+const unusedMatchArgString = `
+function foo
+  input Integer a;
+  input Integer b;
+  input Integer fns;
+  output Boolean res;
+algorithm
+  res := match (a, b, fns)
+    case (1, 2, _) then true;
+    case (_, _, _) then false;
+  end match;
+end foo;
+`;
+
+const usedMatchArgString = `
+function foo
+  input Integer a;
+  input Integer b;
+  output Boolean res;
+algorithm
+  res := match (a, b)
+    case (1, 2) then true;
+    case (_, _) then false;
+  end match;
+end foo;
+`;
+
+const complexArgMatchString = `
+function foo
+  input Integer a;
+  output Boolean res;
+algorithm
+  res := match (someFunc(a), a)
+    case (_, 1) then true;
+    case (_, _) then false;
+  end match;
+end foo;
+`;
+
 suite('getAllDeclarationsInTree', () => {
   test('Definitions and types', async () => {
     const parser = await initializeMetaModelicaParser();
@@ -183,5 +222,48 @@ suite('getAllDeclarationsInTree', () => {
     const diagnostics = getDiagnosticsFromTree(tree, queries);
 
     assert.deepEqual(diagnostics, expectedDiagnostics);
+  });
+
+  test('Detects unused match argument', async () => {
+    const parser = await initializeMetaModelicaParser();
+    const tree = parser.parse(unusedMatchArgString);
+    const queries = new MetaModelicaQueries(parser.getLanguage());
+    const diagnostics = getDiagnosticsFromTree(tree, queries);
+
+    const unused = diagnostics.filter(d => d.message.startsWith('Unused match argument'));
+    assert.strictEqual(unused.length, 1, 'Exactly one unused argument expected');
+
+    const d = unused[0] as LSP.Diagnostic & { data: { unusedArgFix: { argName: string; edits: LSP.TextEdit[] } } };
+    assert.strictEqual(d.message, "Unused match argument 'fns': pattern is '_' in every case.");
+    assert.deepEqual(d.range, { start: { line: 7, character: 22 }, end: { line: 7, character: 25 } });
+    assert.strictEqual(d.severity, LSP.DiagnosticSeverity.Information);
+    assert.strictEqual(d.source, 'MetaModelica-language-server');
+
+    // Fix data: one edit for the input tuple and one per case branch
+    assert.strictEqual(d.data.unusedArgFix.argName, 'fns');
+    assert.strictEqual(d.data.unusedArgFix.edits.length, 3, 'Expect 1 input-tuple edit + 2 case-pattern edits');
+    assert.strictEqual(d.data.unusedArgFix.edits[0].newText, '(a, b)', 'Input tuple without fns');
+    assert.strictEqual(d.data.unusedArgFix.edits[1].newText, '(1, 2)', 'First case pattern without wildcard');
+    assert.strictEqual(d.data.unusedArgFix.edits[2].newText, '(_, _)', 'Second case pattern without wildcard');
+  });
+
+  test('Does not report when all match arguments are used', async () => {
+    const parser = await initializeMetaModelicaParser();
+    const tree = parser.parse(usedMatchArgString);
+    const queries = new MetaModelicaQueries(parser.getLanguage());
+    const diagnostics = getDiagnosticsFromTree(tree, queries);
+
+    const unused = diagnostics.filter(d => d.message.startsWith('Unused match argument'));
+    assert.strictEqual(unused.length, 0);
+  });
+
+  test('Does not flag function-call arguments (only plain identifiers)', async () => {
+    const parser = await initializeMetaModelicaParser();
+    const tree = parser.parse(complexArgMatchString);
+    const queries = new MetaModelicaQueries(parser.getLanguage());
+    const diagnostics = getDiagnosticsFromTree(tree, queries);
+
+    const unused = diagnostics.filter(d => d.message.startsWith('Unused match argument'));
+    assert.strictEqual(unused.length, 0, 'Function-call argument must not be flagged');
   });
 });


### PR DESCRIPTION
## Issue

Fixes https://github.com/OpenModelica/metamodelica-language-server/issues/30.

## Changes

Add an info-level diagnostic that flags arguments of a `match` or `matchcontinue` expression whose pattern is `_` in every case branch and are therefore unused.

<img width="1402" height="631" alt="grafik" src="https://github.com/user-attachments/assets/edbb673f-073e-4915-bc4b-8df84d74f999" />

After quick-fix:

<img width="1291" height="638" alt="grafik" src="https://github.com/user-attachments/assets/de881db4-4bae-47bb-a1fc-607f0e297c4f" />

