### PR TITLE
[CLI] Add mmlsc CLI for applying quick-fixes to .mo files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,50 @@ features:
 
   ![Diagnostics](images/problemMatching.png)
 
+## CLI (`mmlsc`)
+
+The package ships a command-line tool, `mmlsc`, for batch-processing MetaModelica
+source files without opening VS Code.
+
+### Usage
+
+```text
+mmlsc [--fix] <paths...>
+```
+
+| Argument / option | Description |
+| ----------------- | ----------- |
+| `<paths...>` | Files or directories to process. Directories are scanned **recursively** for `.mo` files. |
+| `--fix` | Apply quick-fixes **in-place** and save the modified files. Without this flag the tool only reports issues and exits with `1`. |
+| `--help` | Print usage information. |
+
+### Example
+
+Report all unused `match`/`matchcontinue` arguments in a source tree:
+
+```bash
+node out/cli.js src/
+```
+
+Apply the quick-fix for all detected issues:
+
+```bash
+node out/cli.js --fix src/
+```
+
+When installed globally (`npm install -g .` from the repository root after
+building), the tool is available as:
+
+```bash
+mmlsc --fix src/
+```
+
+### Supported quick-fixes
+
+| Diagnostic | Fix |
+|---|---|
+| Unused `match`/`matchcontinue` argument (pattern is `_` in every case) | Remove the argument from the input tuple and all case patterns |
+
 ## Installation
 
 ### Via Marketplace

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -53,6 +53,30 @@ async function main() {
     await server.rebuild();
     await server.dispose();
   }
+
+  // Build CLI
+  const cli = await esbuild.context({
+    entryPoints: ['./src/cli/cli.ts'],
+    bundle: true,
+    format: 'cjs',
+    minify: production,
+    sourcemap: !production,
+    sourcesContent: false,
+    platform: 'node',
+    outfile: './out/cli.js',
+    external: ['vscode'],
+    logLevel: 'warning',
+    plugins: [
+      /* add to the end of plugins array */
+      esbuildCliProblemMatcherPlugin
+    ]
+  });
+  if (watch) {
+    await cli.watch();
+  } else {
+    await cli.rebuild();
+    await cli.dispose();
+  }
 }
 
 /**
@@ -89,6 +113,23 @@ const esbuildServerProblemMatcherPlugin = {
         console.error(`    ${location.file}:${location.line}:${location.column}:`);
       });
       console.log(`Server${watchStr}build finished`);
+    });
+  }
+};
+const esbuildCliProblemMatcherPlugin = {
+  name: 'esbuild-cli-problem-matcher',
+
+  setup(build) {
+    build.onStart(() => {
+      console.log(`CLI${watchStr}build started`);
+    });
+    build.onEnd(result => {
+      result.errors.forEach(({ text, location }) => {
+        console.error(`✘ CLI${watchStr}build [ERROR] ${text}`);
+        if (location === null) {return;}
+        console.error(`    ${location.file}:${location.line}:${location.column}:`);
+      });
+      console.log(`CLI${watchStr}build finished`);
     });
   }
 };

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -65,6 +65,7 @@ async function main() {
     platform: 'node',
     outfile: './out/cli.js',
     external: ['vscode'],
+    banner: { js: '#!/usr/bin/env node' },
     logLevel: 'warning',
     plugins: [
       /* add to the end of plugins array */
@@ -77,6 +78,7 @@ async function main() {
     await cli.rebuild();
     await cli.dispose();
   }
+  fs.chmodSync('./out/cli.js', 0o755);
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,9 @@
         "vscode-languageserver-textdocument": "^1.0.12",
         "web-tree-sitter": "^0.22.5"
       },
+      "bin": {
+        "mmlsc": "out/cli.js"
+      },
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "^22.13.10",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "bugs": "https://github.com/OpenModelica/metamodelica-language-server/issues",
   "engines": {
     "vscode": "^1.98.0",
-    "node": "22"
+    "node": ">=22"
   },
   "activationEvents": [
     "onLanguage:metamodelica",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,9 @@
       }
     ]
   },
+  "bin": {
+    "mmlsc": "./out/cli.js"
+  },
   "scripts": {
     "vscode:prepublish": "node esbuild.config.js --minify",
     "esbuild": "node esbuild.config.js",

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,0 +1,192 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import * as LSP from 'vscode-languageserver/node';
+
+import { initializeMetaModelicaParser } from '../server/metaModelicaParser';
+import Analyzer from '../server/analyzer';
+import { UnusedArgFix } from '../server/diagnostics';
+
+export interface ProcessResult {
+  filesProcessed: number;
+  issuesFound: number;
+  issuesFixed: number;
+}
+
+/**
+ * Recursively collect all .mo files under a path.
+ * If path is a file it is returned directly (if it ends with .mo).
+ */
+function findMoFiles(inputPath: string): string[] {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(inputPath);
+  } catch {
+    throw new Error(`Path not found: ${inputPath}`);
+  }
+
+  if (stat.isFile()) {
+    return inputPath.endsWith('.mo') ? [inputPath] : [];
+  }
+
+  if (stat.isDirectory()) {
+    const results: string[] = [];
+    for (const entry of fs.readdirSync(inputPath, { withFileTypes: true })) {
+      results.push(...findMoFiles(path.join(inputPath, entry.name)));
+    }
+    return results;
+  }
+
+  return [];
+}
+
+/**
+ * Apply a list of LSP TextEdits to a string, returning the modified string.
+ */
+function applyEdits(content: string, uri: string, edits: LSP.TextEdit[]): string {
+  const doc = TextDocument.create(uri, 'metamodelica', 1, content);
+  return TextDocument.applyEdits(doc, edits);
+}
+
+/**
+ * Process a set of file/directory paths: detect unused match arguments and
+ * optionally apply the quick-fixes in-place.
+ *
+ * @param paths  File or directory paths to process.
+ * @param fix    When true, apply quick-fixes and save files. When false, only report.
+ * @returns      Summary of what was found and fixed.
+ */
+export async function processFiles(paths: string[], fix: boolean): Promise<ProcessResult> {
+  const parser = await initializeMetaModelicaParser();
+  const analyzer = new Analyzer(parser);
+
+  const moFiles: string[] = [];
+  for (const p of paths) {
+    moFiles.push(...findMoFiles(p));
+  }
+
+  let totalIssuesFound = 0;
+  let totalIssuesFixed = 0;
+
+  for (const filePath of moFiles) {
+    const absPath = path.resolve(filePath);
+    const uri = `file://${absPath}`;
+    let content = fs.readFileSync(absPath, 'utf-8');
+
+    if (fix) {
+      // Apply fixes one at a time, re-parsing after each (positions shift after edits).
+      let fixed = 0;
+      let hasMore = true;
+      while (hasMore) {
+        hasMore = false;
+        const doc = TextDocument.create(uri, 'metamodelica', 1, content);
+        const diagnostics = analyzer.analyze(doc);
+        for (const diagnostic of diagnostics) {
+          const data = diagnostic.data as { unusedArgFix?: UnusedArgFix } | undefined;
+          if (data?.unusedArgFix) {
+            content = applyEdits(content, uri, data.unusedArgFix.edits);
+            fixed++;
+            hasMore = true;
+            break; // restart scan; positions are now stale
+          }
+        }
+      }
+      if (fixed > 0) {
+        fs.writeFileSync(absPath, content);
+        console.log(`${filePath}: fixed ${fixed} issue(s)`);
+      }
+      totalIssuesFixed += fixed;
+    } else {
+      const doc = TextDocument.create(uri, 'metamodelica', 1, content);
+      const diagnostics = analyzer.analyze(doc);
+      let count = 0;
+      for (const diagnostic of diagnostics) {
+        const data = diagnostic.data as { unusedArgFix?: UnusedArgFix } | undefined;
+        if (data?.unusedArgFix) {
+          const { line, character } = diagnostic.range.start;
+          console.log(`${filePath}:${line + 1}:${character + 1}: ${diagnostic.message}`);
+          count++;
+        }
+      }
+      totalIssuesFound += count;
+    }
+  }
+
+  return {
+    filesProcessed: moFiles.length,
+    issuesFound: totalIssuesFound,
+    issuesFixed: totalIssuesFixed,
+  };
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    console.log(
+      'Usage: mmlsc [--fix] <paths...>\n\n' +
+      '  --fix    Apply quick-fixes to files in-place (default: report only)\n' +
+      '  --help   Show this help\n\n' +
+      '  paths    Files or directories to process (.mo files, directories are scanned recursively)'
+    );
+    process.exit(0);
+  }
+
+  const fix = args.includes('--fix');
+  const paths = args.filter(a => !a.startsWith('--'));
+
+  try {
+    const result = await processFiles(paths, fix);
+
+    if (fix) {
+      console.log(`Processed ${result.filesProcessed} file(s), fixed ${result.issuesFixed} issue(s).`);
+      process.exit(0);
+    } else {
+      console.log(`Processed ${result.filesProcessed} file(s), found ${result.issuesFound} issue(s).`);
+      process.exit(result.issuesFound > 0 ? 1 : 0);
+    }
+  } catch (err) {
+    console.error('Error:', err instanceof Error ? err.message : err);
+    process.exit(2);
+  }
+}
+
+// Only run main() when executed directly (not when imported by tests).
+if (require.main === module) {
+  main();
+}

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -1,0 +1,157 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { processFiles } from '../../src/cli/cli';
+
+const unusedArgSource = `function foo
+  input Integer a;
+  input Integer b;
+  input Integer fns;
+  output Boolean res;
+algorithm
+  res := match (a, b, fns)
+    case (1, 2, _) then true;
+    case (_, _, _) then false;
+  end match;
+end foo;
+`;
+
+// After the fix, `fns` and its wildcard patterns should be removed.
+const unusedArgFixed = `function foo
+  input Integer a;
+  input Integer b;
+  input Integer fns;
+  output Boolean res;
+algorithm
+  res := match (a, b)
+    case (1, 2) then true;
+    case (_, _) then false;
+  end match;
+end foo;
+`;
+
+const noIssueSource = `function bar
+  input Integer a;
+  output Boolean res;
+algorithm
+  res := match (a)
+    case (1) then true;
+    case (_) then false;
+  end match;
+end bar;
+`;
+
+suite('CLI processFiles', () => {
+  let tmpDir: string;
+
+  setup(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mmlsc-test-'));
+  });
+
+  teardown(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('detects unused match argument (report mode)', async () => {
+    const filePath = path.join(tmpDir, 'unused.mo');
+    fs.writeFileSync(filePath, unusedArgSource);
+
+    const result = await processFiles([filePath], false);
+
+    assert.strictEqual(result.filesProcessed, 1);
+    assert.strictEqual(result.issuesFound, 1);
+    assert.strictEqual(result.issuesFixed, 0);
+
+    // File must not be modified in report mode.
+    assert.strictEqual(fs.readFileSync(filePath, 'utf-8'), unusedArgSource);
+  });
+
+  test('fixes unused match argument in-place (fix mode)', async () => {
+    const filePath = path.join(tmpDir, 'unused.mo');
+    fs.writeFileSync(filePath, unusedArgSource);
+
+    const result = await processFiles([filePath], true);
+
+    assert.strictEqual(result.filesProcessed, 1);
+    assert.strictEqual(result.issuesFixed, 1);
+
+    const fixed = fs.readFileSync(filePath, 'utf-8');
+    assert.strictEqual(fixed, unusedArgFixed);
+  });
+
+  test('reports zero issues for a clean file', async () => {
+    const filePath = path.join(tmpDir, 'clean.mo');
+    fs.writeFileSync(filePath, noIssueSource);
+
+    const result = await processFiles([filePath], false);
+
+    assert.strictEqual(result.filesProcessed, 1);
+    assert.strictEqual(result.issuesFound, 0);
+  });
+
+  test('scans directory recursively for .mo files', async () => {
+    const subDir = path.join(tmpDir, 'sub');
+    fs.mkdirSync(subDir);
+    fs.writeFileSync(path.join(tmpDir, 'a.mo'), unusedArgSource);
+    fs.writeFileSync(path.join(subDir, 'b.mo'), unusedArgSource);
+    // A non-.mo file should be ignored.
+    fs.writeFileSync(path.join(tmpDir, 'notes.txt'), 'not modelica');
+
+    const result = await processFiles([tmpDir], false);
+
+    assert.strictEqual(result.filesProcessed, 2);
+    assert.strictEqual(result.issuesFound, 2);
+  });
+
+  test('fixes multiple files in a directory (fix mode)', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'a.mo'), unusedArgSource);
+    fs.writeFileSync(path.join(tmpDir, 'b.mo'), unusedArgSource);
+
+    const result = await processFiles([tmpDir], true);
+
+    assert.strictEqual(result.filesProcessed, 2);
+    assert.strictEqual(result.issuesFixed, 2);
+
+    for (const name of ['a.mo', 'b.mo']) {
+      const content = fs.readFileSync(path.join(tmpDir, name), 'utf-8');
+      assert.strictEqual(content, unusedArgFixed);
+    }
+  });
+});

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2024, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *


### PR DESCRIPTION
Adds a command-line tool (`mmlsc`) that processes MetaModelica source files and can detect or auto-fix unused match/matchcontinue arguments.

- `mmlsc <paths...>` reports unused match argument issues (exit 1 if any found)
- `mmlsc --fix <paths...>` applies the quick-fix in-place and saves files
- Directories are scanned recursively for `.mo` files
- Fixes are applied one at a time with re-parsing between each to keep positions correct when multiple unused args exist in the same match

Also adds esbuild target for `out/cli.js` and a `bin` entry in package.json so the tool can be used as `mmlsc` after `npm install -g`.

Closes #32

## Example usage

```bash
> cd path/to/OpenModelica
> node /path/to/metamodelica-language-server/out/cli.js OMCompiler/Compiler/BackEnd/BackendInline.mo
OMCompiler/Compiler/BackEnd/BackendInline.mo:190:53: Unused match argument 'fns': pattern is '_' in every case.
OMCompiler/Compiler/BackEnd/BackendInline.mo:291:46: Unused match argument 'inFunctions': pattern is '_' in every case.
OMCompiler/Compiler/BackEnd/BackendInline.mo:291:58: Unused match argument 'iAcc': pattern is '_' in every case.
OMCompiler/Compiler/BackEnd/BackendInline.mo:291:63: Unused match argument 'iInlined': pattern is '_' in every case.
OMCompiler/Compiler/BackEnd/BackendInline.mo:314:46: Unused match argument 'inFunctions': pattern is '_' in every case.
OMCompiler/Compiler/BackEnd/BackendInline.mo:314:58: Unused match argument 'iAcc': pattern is '_' in every case.
OMCompiler/Compiler/BackEnd/BackendInline.mo:314:63: Unused match argument 'iInlined': pattern is '_' in every case.
OMCompiler/Compiler/BackEnd/BackendInline.mo:479:47: Unused match argument 'fns': pattern is '_' in every case.
OMCompiler/Compiler/BackEnd/BackendInline.mo:1153:22: Unused match argument 'iExp': pattern is '_' in every case.
OMCompiler/Compiler/BackEnd/BackendInline.mo:1153:27: Unused match argument 'iRepl': pattern is '_' in every case.
Processed 1 file(s), found 10 issue(s).
> node /path/to/metamodelica-language-server/out/cli.js OMCompiler/Compiler/BackEnd/BackendInline.mo --fix
OMCompiler/Compiler/BackEnd/BackendInline.mo: fixed 10 issue(s)
Processed 1 file(s), fixed 10 issue(s).
```