### PR TITLE
Detect unused variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,41 +30,45 @@ source files without opening VS Code.
 ### Usage
 
 ```text
-mmlsc [--fix] <paths...>
+mmlsc [--fix] [--check <name>]... <paths...>
 ```
 
 | Argument / option | Description |
 | ----------------- | ----------- |
 | `<paths...>` | Files or directories to process. Directories are scanned **recursively** for `.mo` files. |
 | `--fix` | Apply quick-fixes **in-place** and save the modified files. Without this flag the tool only reports issues and exits with `1`. |
+| `--check <name>` | Limit processing to a specific check (repeatable). When omitted all checks run. See [Supported quick-fixes](#supported-quick-fixes) for available names. |
 | `--help` | Print usage information. |
 
 ### Example
 
-Report all unused `match`/`matchcontinue` arguments in a source tree:
+Report all issues in a source tree:
 
 ```bash
-node out/cli.js src/
+mmlsc src/
 ```
 
-Apply the quick-fix for all detected issues:
-
-```bash
-node out/cli.js --fix src/
-```
-
-When installed globally (`npm install -g .` from the repository root after
-building), the tool is available as:
+Apply quick-fixes for all detected issues:
 
 ```bash
 mmlsc --fix src/
 ```
 
+Apply only the unused-variable fix:
+
+```bash
+mmlsc --fix --check unused-var src/
+```
+
+When installed globally (`npm install -g .` from the repository root after
+building), the tool is available as `mmlsc`.
+
 ### Supported quick-fixes
 
-| Diagnostic | Fix |
-|---|---|
-| Unused `match`/`matchcontinue` argument (pattern is `_` in every case) | Remove the argument from the input tuple and all case patterns |
+| Check name | Diagnostic | Fix |
+| --- | --- | --- |
+| `unused-var` | Unused variable in a `protected` section or `local` block | Remove the variable declaration |
+| `unused-match-arg` | Unused `match`/`matchcontinue` argument (pattern is `_` in every case) | Remove the argument from the input tuple and all case patterns |
 
 ## Installation
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -40,7 +40,7 @@ import * as LSP from 'vscode-languageserver/node';
 
 import { initializeMetaModelicaParser } from '../server/metaModelicaParser';
 import Analyzer from '../server/analyzer';
-import { UnusedArgFix } from '../server/diagnostics';
+import { UnusedArgFix, UnusedVarFix } from '../server/diagnostics';
 
 export interface ProcessResult {
   filesProcessed: number;
@@ -117,9 +117,10 @@ export async function processFiles(paths: string[], fix: boolean): Promise<Proce
         const doc = TextDocument.create(uri, 'metamodelica', 1, content);
         const diagnostics = analyzer.analyze(doc);
         for (const diagnostic of diagnostics) {
-          const data = diagnostic.data as { unusedArgFix?: UnusedArgFix } | undefined;
-          if (data?.unusedArgFix) {
-            content = applyEdits(content, uri, data.unusedArgFix.edits);
+          const data = diagnostic.data as { unusedArgFix?: UnusedArgFix; unusedVarFix?: UnusedVarFix } | undefined;
+          const edits = data?.unusedArgFix?.edits ?? data?.unusedVarFix?.edits;
+          if (edits) {
+            content = applyEdits(content, uri, edits);
             fixed++;
             hasMore = true;
             break; // restart scan; positions are now stale
@@ -136,8 +137,8 @@ export async function processFiles(paths: string[], fix: boolean): Promise<Proce
       const diagnostics = analyzer.analyze(doc);
       let count = 0;
       for (const diagnostic of diagnostics) {
-        const data = diagnostic.data as { unusedArgFix?: UnusedArgFix } | undefined;
-        if (data?.unusedArgFix) {
+        const data = diagnostic.data as { unusedArgFix?: UnusedArgFix; unusedVarFix?: UnusedVarFix } | undefined;
+        if (data?.unusedArgFix || data?.unusedVarFix) {
           const { line, character } = diagnostic.range.start;
           console.log(`${filePath}:${line + 1}:${character + 1}: ${diagnostic.message}`);
           count++;

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -42,6 +42,10 @@ import { initializeMetaModelicaParser } from '../server/metaModelicaParser';
 import Analyzer from '../server/analyzer';
 import { UnusedArgFix, UnusedVarFix } from '../server/diagnostics';
 
+export type CheckName = 'unused-var' | 'unused-match-arg';
+
+export const ALL_CHECKS: CheckName[] = ['unused-var', 'unused-match-arg'];
+
 export interface ProcessResult {
   filesProcessed: number;
   issuesFound: number;
@@ -84,14 +88,33 @@ function applyEdits(content: string, uri: string, edits: LSP.TextEdit[]): string
 }
 
 /**
- * Process a set of file/directory paths: detect unused match arguments and
- * optionally apply the quick-fixes in-place.
- *
- * @param paths  File or directory paths to process.
- * @param fix    When true, apply quick-fixes and save files. When false, only report.
- * @returns      Summary of what was found and fixed.
+ * Return the fix edits for a diagnostic if it matches one of the requested
+ * checks, or undefined if it should be skipped.
  */
-export async function processFiles(paths: string[], fix: boolean): Promise<ProcessResult> {
+function getFixEdits(
+  data: { unusedArgFix?: UnusedArgFix; unusedVarFix?: UnusedVarFix } | undefined,
+  checks: Set<CheckName>,
+): LSP.TextEdit[] | undefined {
+  if (!data) { return undefined; }
+  if (checks.has('unused-match-arg') && data.unusedArgFix) { return data.unusedArgFix.edits; }
+  if (checks.has('unused-var') && data.unusedVarFix) { return data.unusedVarFix.edits; }
+  return undefined;
+}
+
+/**
+ * Process a set of file/directory paths: detect issues and optionally apply
+ * the quick-fixes in-place.
+ *
+ * @param paths   File or directory paths to process.
+ * @param fix     When true, apply quick-fixes and save files. When false, only report.
+ * @param checks  Which checks to run/fix. Defaults to all checks.
+ * @returns       Summary of what was found and fixed.
+ */
+export async function processFiles(
+  paths: string[],
+  fix: boolean,
+  checks: Set<CheckName> = new Set(ALL_CHECKS),
+): Promise<ProcessResult> {
   const parser = await initializeMetaModelicaParser();
   const analyzer = new Analyzer(parser);
 
@@ -118,7 +141,7 @@ export async function processFiles(paths: string[], fix: boolean): Promise<Proce
         const diagnostics = analyzer.analyze(doc);
         for (const diagnostic of diagnostics) {
           const data = diagnostic.data as { unusedArgFix?: UnusedArgFix; unusedVarFix?: UnusedVarFix } | undefined;
-          const edits = data?.unusedArgFix?.edits ?? data?.unusedVarFix?.edits;
+          const edits = getFixEdits(data, checks);
           if (edits) {
             content = applyEdits(content, uri, edits);
             fixed++;
@@ -138,7 +161,7 @@ export async function processFiles(paths: string[], fix: boolean): Promise<Proce
       let count = 0;
       for (const diagnostic of diagnostics) {
         const data = diagnostic.data as { unusedArgFix?: UnusedArgFix; unusedVarFix?: UnusedVarFix } | undefined;
-        if (data?.unusedArgFix || data?.unusedVarFix) {
+        if (getFixEdits(data, checks)) {
           const { line, character } = diagnostic.range.start;
           console.log(`${filePath}:${line + 1}:${character + 1}: ${diagnostic.message}`);
           count++;
@@ -160,19 +183,48 @@ async function main(): Promise<void> {
 
   if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
     console.log(
-      'Usage: mmlsc [--fix] <paths...>\n\n' +
-      '  --fix    Apply quick-fixes to files in-place (default: report only)\n' +
-      '  --help   Show this help\n\n' +
+      'Usage: mmlsc [--fix] [--check <name>]... <paths...>\n\n' +
+      '  --fix            Apply quick-fixes to files in-place (default: report only)\n' +
+      '  --check <name>   Limit to a specific check (repeatable; default: all checks)\n' +
+      '  --help           Show this help\n\n' +
+      '  Available check names:\n' +
+      '    unused-var         Unused protected/local variables\n' +
+      '    unused-match-arg   Unused match/matchcontinue arguments\n\n' +
       '  paths    Files or directories to process (.mo files, directories are scanned recursively)'
     );
     process.exit(0);
   }
 
   const fix = args.includes('--fix');
-  const paths = args.filter(a => !a.startsWith('--'));
+
+  // Collect --check <name> pairs
+  const requestedChecks: CheckName[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--check') {
+      const name = args[i + 1];
+      if (!name || name.startsWith('--')) {
+        console.error('Error: --check requires a check name argument');
+        process.exit(2);
+      }
+      if (!(ALL_CHECKS as string[]).includes(name)) {
+        console.error(`Error: unknown check '${name}'. Available: ${ALL_CHECKS.join(', ')}`);
+        process.exit(2);
+      }
+      requestedChecks.push(name as CheckName);
+      i++; // skip the name argument
+    }
+  }
+
+  const checks = requestedChecks.length > 0
+    ? new Set(requestedChecks)
+    : new Set(ALL_CHECKS);
+
+  const paths = args.filter((a, i) =>
+    !a.startsWith('--') && (i === 0 || args[i - 1] !== '--check')
+  );
 
   try {
-    const result = await processFiles(paths, fix);
+    const result = await processFiles(paths, fix, checks);
 
     if (fix) {
       console.log(`Processed ${result.filesProcessed} file(s), fixed ${result.issuesFixed} issue(s).`);

--- a/src/server/diagnostics.ts
+++ b/src/server/diagnostics.ts
@@ -45,6 +45,11 @@ export interface UnusedArgFix {
   edits: LSP.TextEdit[];
 }
 
+export interface UnusedVarFix {
+  varName: string;
+  edits: LSP.TextEdit[];
+}
+
 /**
  * Extract tuple element expressions from a `(a, b, c)` expression node.
  * Returns null if the expression is not a parenthesized tuple with at least two elements.
@@ -90,6 +95,171 @@ function buildTupleNewText(elements: Parser.SyntaxNode[], skipIndex: number): st
   const remaining = elements.filter((_, i) => i !== skipIndex).map(e => e.text);
   if (remaining.length === 1) { return remaining[0]; }
   return '(' + remaining.join(', ') + ')';
+}
+
+/**
+ * Get the IDENT node from a component_declaration node.
+ * In the grammar: component_declaration → declaration → IDENT (field: identifier)
+ */
+function getDeclIdent(decl: Parser.SyntaxNode): Parser.SyntaxNode | null {
+  const declNode = decl.namedChildren.find(c => c.type === 'declaration');
+  if (!declNode) { return null; }
+  return declNode.namedChildren.find(c => c.type === 'IDENT') || null;
+}
+
+/**
+ * Return true if `name` appears as any IDENT node inside `scope`,
+ * excluding the subtree rooted at `skipNode` (the declaration element).
+ */
+function isNameUsed(name: string, scope: Parser.SyntaxNode, skipNode: Parser.SyntaxNode): boolean {
+  let found = false;
+  const skipStart = skipNode.startIndex;
+  const skipEnd = skipNode.endIndex;
+
+  function visit(node: Parser.SyntaxNode): void {
+    if (found) { return; }
+    if (node.startIndex === skipStart && node.endIndex === skipEnd) { return; }
+    if (node.type === 'IDENT' && node.text === name) {
+      found = true;
+      return;
+    }
+    for (const child of node.children) {
+      if (found) { return; }
+      visit(child);
+    }
+  }
+
+  visit(scope);
+  return found;
+}
+
+/**
+ * Build LSP TextEdits to remove a single component_declaration from its
+ * parent element.  When it is the only declaration the entire element line
+ * is removed; otherwise the declaration is excised from the comma-separated
+ * list.
+ */
+function buildVarRemoveEdits(
+  elementNode: Parser.SyntaxNode,
+  componentClause: Parser.SyntaxNode,
+  targetDecl: Parser.SyntaxNode,
+): LSP.TextEdit[] {
+  const declarations = componentClause.namedChildren.filter(c => c.type === 'component_declaration');
+
+  if (declarations.length === 1) {
+    return [{
+      range: LSP.Range.create(
+        elementNode.startPosition.row, 0,
+        elementNode.endPosition.row + 1, 0,
+      ),
+      newText: '',
+    }];
+  }
+
+  const idx = declarations.indexOf(targetDecl);
+  const allChildren = componentClause.children;
+  const nodeIdx = allChildren.findIndex(c => c.startIndex === targetDecl.startIndex);
+
+  if (nodeIdx === -1) {
+    return [{ range: TreeSitterUtil.range(targetDecl), newText: '' }];
+  }
+
+  if (idx < declarations.length - 1) {
+    // Not the last: remove "name, " by spanning to the start of the next declaration
+    const nextDecl = declarations[idx + 1];
+    return [{
+      range: LSP.Range.create(
+        targetDecl.startPosition.row, targetDecl.startPosition.column,
+        nextDecl.startPosition.row, nextDecl.startPosition.column,
+      ),
+      newText: '',
+    }];
+  } else {
+    // Last: remove ", name" by spanning back to the preceding COMMA
+    let commaNode: Parser.SyntaxNode | null = null;
+    for (let i = nodeIdx - 1; i >= 0; i--) {
+      if (allChildren[i].type === 'COMMA') {
+        commaNode = allChildren[i];
+        break;
+      }
+    }
+    if (!commaNode) {
+      return [{ range: TreeSitterUtil.range(targetDecl), newText: '' }];
+    }
+    return [{
+      range: LSP.Range.create(
+        commaNode.startPosition.row, commaNode.startPosition.column,
+        targetDecl.endPosition.row, targetDecl.endPosition.column,
+      ),
+      newText: '',
+    }];
+  }
+}
+
+/**
+ * Check all component_declarations within an element node for unused variables.
+ */
+function checkElementDeclarations(
+  elementNode: Parser.SyntaxNode,
+  scope: Parser.SyntaxNode,
+  results: { varNode: Parser.SyntaxNode; fix: UnusedVarFix }[],
+): void {
+  const componentClause = elementNode.namedChildren.find(c => c.type === 'component_clause');
+  if (!componentClause) { return; }
+
+  const declarations = componentClause.namedChildren.filter(c => c.type === 'component_declaration');
+  for (const decl of declarations) {
+    const identNode = getDeclIdent(decl);
+    if (!identNode) { continue; }
+    const name = identNode.text;
+    if (!isNameUsed(name, scope, elementNode)) {
+      results.push({
+        varNode: identNode,
+        fix: {
+          varName: name,
+          edits: buildVarRemoveEdits(elementNode, componentClause, decl),
+        },
+      });
+    }
+  }
+}
+
+/**
+ * Find unused protected variables in function bodies and unused local
+ * variables inside match/matchcontinue expressions.
+ */
+function getUnusedVariables(rootNode: Parser.SyntaxNode): { varNode: Parser.SyntaxNode; fix: UnusedVarFix }[] {
+  const results: { varNode: Parser.SyntaxNode; fix: UnusedVarFix }[] = [];
+
+  TreeSitterUtil.forEach(rootNode, (node) => {
+    // Protected variables declared inside a composition (function body)
+    if (node.type === 'composition') {
+      let inProtected = false;
+      for (const child of node.children) {
+        if (child.type === 'PROTECTED') { inProtected = true; continue; }
+        if (child.type === 'PUBLIC') { inProtected = false; continue; }
+        if (inProtected && child.type === 'element') {
+          checkElementDeclarations(child, node, results);
+        }
+      }
+    }
+
+    // Local variables declared in a match/matchcontinue local clause
+    if (node.type === 'match_expression') {
+      const localClause = node.namedChildren.find(c => c.type === 'local_clause');
+      if (localClause) {
+        for (const child of localClause.namedChildren) {
+          if (child.type === 'element') {
+            checkElementDeclarations(child, node, results);
+          }
+        }
+      }
+    }
+
+    return true;
+  });
+
+  return results;
 }
 
 /**
@@ -226,6 +396,17 @@ export function getDiagnosticsFromTree(tree: Parser.Tree, queries: MetaModelicaQ
         LSP.DiagnosticSeverity.Information,
         "'matchcontinue' is inefficient, use 'match' and 'try-catch' instead."));
     }
+  }
+
+  // Inform about unused protected / local variables
+  const unusedVars = getUnusedVariables(tree.rootNode);
+  for (const { varNode, fix } of unusedVars) {
+    const diagnostic = nodeToDiagnostic(
+      varNode,
+      LSP.DiagnosticSeverity.Information,
+      `Unused variable '${varNode.text}'.`);
+    (diagnostic as LSP.Diagnostic & { data: unknown }).data = { unusedVarFix: fix };
+    diagnostics.push(diagnostic);
   }
 
   // Inform about unused match/matchcontinue arguments

--- a/src/server/extension.ts
+++ b/src/server/extension.ts
@@ -45,7 +45,7 @@ import { TextDocument} from 'vscode-languageserver-textdocument';
 import { initializeMetaModelicaParser } from './metaModelicaParser';
 import Analyzer from './analyzer';
 import { logger, setLogConnection, setLogLevel } from '../util/logger';
-import { UnusedArgFix } from './diagnostics';
+import { UnusedArgFix, UnusedVarFix } from './diagnostics';
 
 /**
  * MetaModelicaServer collection all the important bits and bobs.
@@ -153,11 +153,25 @@ export class MetaModelicaServer {
   private onCodeAction(params: LSP.CodeActionParams): LSP.CodeAction[] {
     const actions: LSP.CodeAction[] = [];
     for (const diagnostic of params.context.diagnostics) {
-      const data = diagnostic.data as { unusedArgFix?: UnusedArgFix } | undefined;
+      const data = diagnostic.data as { unusedArgFix?: UnusedArgFix; unusedVarFix?: UnusedVarFix } | undefined;
       if (data?.unusedArgFix) {
         const fix = data.unusedArgFix;
         actions.push({
           title: `Remove unused argument '${fix.argName}'`,
+          kind: LSP.CodeActionKind.QuickFix,
+          diagnostics: [diagnostic],
+          isPreferred: true,
+          edit: {
+            changes: {
+              [params.textDocument.uri]: fix.edits
+            }
+          }
+        });
+      }
+      if (data?.unusedVarFix) {
+        const fix = data.unusedVarFix;
+        actions.push({
+          title: `Remove unused variable '${fix.varName}'`,
           kind: LSP.CodeActionKind.QuickFix,
           diagnostics: [diagnostic],
           isPreferred: true,

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -38,7 +38,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import { processFiles } from '../../src/cli/cli';
+import { processFiles, ALL_CHECKS } from '../../src/cli/cli';
 
 const unusedArgSource = `function foo
   input Integer a;
@@ -199,5 +199,61 @@ suite('CLI processFiles', () => {
       const content = fs.readFileSync(path.join(tmpDir, name), 'utf-8');
       assert.strictEqual(content, unusedArgFixed);
     }
+  });
+
+  // ── --check filter ─────────────────────────────────────────────────────
+
+  // A file that has both kinds of issue: one unused match arg and one unused protected var.
+  const bothIssuesSource = `function foo
+  input Integer a;
+  input Integer unused_arg;
+  output Integer res;
+protected
+  Integer unused_var;
+algorithm
+  res := match (a, unused_arg)
+    case (1, _) then 1;
+    case (_, _) then 0;
+  end match;
+end foo;
+`;
+
+  test('--check unused-var reports only unused variables', async () => {
+    const filePath = path.join(tmpDir, 'both.mo');
+    fs.writeFileSync(filePath, bothIssuesSource);
+
+    const result = await processFiles([filePath], false, new Set(['unused-var']));
+
+    assert.strictEqual(result.issuesFound, 1, 'Only the unused-var issue should be reported');
+  });
+
+  test('--check unused-match-arg reports only unused match arguments', async () => {
+    const filePath = path.join(tmpDir, 'both.mo');
+    fs.writeFileSync(filePath, bothIssuesSource);
+
+    const result = await processFiles([filePath], false, new Set(['unused-match-arg']));
+
+    assert.strictEqual(result.issuesFound, 1, 'Only the unused-match-arg issue should be reported');
+  });
+
+  test('all checks active by default (reports both issue types)', async () => {
+    const filePath = path.join(tmpDir, 'both.mo');
+    fs.writeFileSync(filePath, bothIssuesSource);
+
+    const result = await processFiles([filePath], false, new Set(ALL_CHECKS));
+
+    assert.strictEqual(result.issuesFound, 2, 'Both issue types should be reported');
+  });
+
+  test('--check unused-var fix mode leaves match-arg issues untouched', async () => {
+    const filePath = path.join(tmpDir, 'both.mo');
+    fs.writeFileSync(filePath, bothIssuesSource);
+
+    const result = await processFiles([filePath], true, new Set(['unused-var']));
+
+    assert.strictEqual(result.issuesFixed, 1);
+    // The unused match-arg issue must still be present after the fix.
+    const remaining = await processFiles([filePath], false, new Set(['unused-match-arg']));
+    assert.strictEqual(remaining.issuesFound, 1, 'Unused match arg should remain unfixed');
   });
 });

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -67,6 +67,29 @@ algorithm
 end foo;
 `;
 
+const unusedProtectedVarSource = `function addOne
+  input Integer x;
+  output Integer y;
+protected
+  Integer unused;
+  Integer tmp;
+algorithm
+  tmp := x + 1;
+  y := tmp;
+end addOne;
+`;
+
+const unusedProtectedVarFixed = `function addOne
+  input Integer x;
+  output Integer y;
+protected
+  Integer tmp;
+algorithm
+  tmp := x + 1;
+  y := tmp;
+end addOne;
+`;
+
 const noIssueSource = `function bar
   input Integer a;
   output Boolean res;
@@ -138,6 +161,29 @@ suite('CLI processFiles', () => {
 
     assert.strictEqual(result.filesProcessed, 2);
     assert.strictEqual(result.issuesFound, 2);
+  });
+
+  test('detects unused protected variable (report mode)', async () => {
+    const filePath = path.join(tmpDir, 'unused_var.mo');
+    fs.writeFileSync(filePath, unusedProtectedVarSource);
+
+    const result = await processFiles([filePath], false);
+
+    assert.strictEqual(result.filesProcessed, 1);
+    assert.strictEqual(result.issuesFound, 1);
+    assert.strictEqual(result.issuesFixed, 0);
+    assert.strictEqual(fs.readFileSync(filePath, 'utf-8'), unusedProtectedVarSource);
+  });
+
+  test('fixes unused protected variable in-place (fix mode)', async () => {
+    const filePath = path.join(tmpDir, 'unused_var.mo');
+    fs.writeFileSync(filePath, unusedProtectedVarSource);
+
+    const result = await processFiles([filePath], true);
+
+    assert.strictEqual(result.filesProcessed, 1);
+    assert.strictEqual(result.issuesFixed, 1);
+    assert.strictEqual(fs.readFileSync(filePath, 'utf-8'), unusedProtectedVarFixed);
   });
 
   test('fixes multiple files in a directory (fix mode)', async () => {

--- a/test/server/diagnostics.test.ts
+++ b/test/server/diagnostics.test.ts
@@ -257,6 +257,126 @@ suite('getAllDeclarationsInTree', () => {
     assert.strictEqual(unused.length, 0);
   });
 
+  // ── Unused protected variables ─────────────────────────────────────────
+
+  const unusedProtectedVarString = `
+function addOne
+  input Integer x;
+  output Integer y;
+protected
+  Integer unused;
+  Integer tmp;
+algorithm
+  tmp := x + 1;
+  y := tmp;
+end addOne;
+`;
+
+  const usedProtectedVarString = `
+function addOne
+  input Integer x;
+  output Integer y;
+protected
+  Integer tmp;
+algorithm
+  tmp := x + 1;
+  y := tmp;
+end addOne;
+`;
+
+  test('Detects unused protected variable', async () => {
+    const parser = await initializeMetaModelicaParser();
+    const tree = parser.parse(unusedProtectedVarString);
+    const queries = new MetaModelicaQueries(parser.getLanguage());
+    const diagnostics = getDiagnosticsFromTree(tree, queries);
+
+    const unused = diagnostics.filter(d => d.message.startsWith('Unused variable'));
+    assert.strictEqual(unused.length, 1, 'Exactly one unused variable expected');
+
+    const d = unused[0] as LSP.Diagnostic & { data: { unusedVarFix: { varName: string; edits: LSP.TextEdit[] } } };
+    assert.strictEqual(d.message, "Unused variable 'unused'.");
+    assert.strictEqual(d.severity, LSP.DiagnosticSeverity.Information);
+    assert.strictEqual(d.source, 'MetaModelica-language-server');
+
+    assert.strictEqual(d.data.unusedVarFix.varName, 'unused');
+    assert.strictEqual(d.data.unusedVarFix.edits.length, 1);
+    assert.strictEqual(d.data.unusedVarFix.edits[0].newText, '', 'Fix should delete the declaration line');
+  });
+
+  test('Does not report used protected variables', async () => {
+    const parser = await initializeMetaModelicaParser();
+    const tree = parser.parse(usedProtectedVarString);
+    const queries = new MetaModelicaQueries(parser.getLanguage());
+    const diagnostics = getDiagnosticsFromTree(tree, queries);
+
+    const unused = diagnostics.filter(d => d.message.startsWith('Unused variable'));
+    assert.strictEqual(unused.length, 0);
+  });
+
+  // ── Unused local variables in match ────────────────────────────────────
+
+  const unusedLocalVarString = `
+function inlineEqsLst
+  input list<Integer> inList;
+  output list<Integer> outList;
+algorithm
+  outList := match(inList)
+    local
+      Integer elem;
+      Integer unused;
+    case ({}) then {};
+    case (elem :: _) then {elem};
+  end match;
+end inlineEqsLst;
+`;
+
+  const unusedLocalMultiDeclString = `
+function foo
+  input list<Integer> xs;
+  output Integer res;
+algorithm
+  res := match(xs)
+    local
+      Integer a, unused;
+    case ({}) then 0;
+    case (a :: _) then a;
+  end match;
+end foo;
+`;
+
+  test('Detects unused local variable in match', async () => {
+    const parser = await initializeMetaModelicaParser();
+    const tree = parser.parse(unusedLocalVarString);
+    const queries = new MetaModelicaQueries(parser.getLanguage());
+    const diagnostics = getDiagnosticsFromTree(tree, queries);
+
+    const unused = diagnostics.filter(d => d.message.startsWith('Unused variable'));
+    assert.strictEqual(unused.length, 1, 'Exactly one unused local variable expected');
+
+    const d = unused[0] as LSP.Diagnostic & { data: { unusedVarFix: { varName: string; edits: LSP.TextEdit[] } } };
+    assert.strictEqual(d.message, "Unused variable 'unused'.");
+    assert.strictEqual(d.data.unusedVarFix.varName, 'unused');
+    assert.strictEqual(d.data.unusedVarFix.edits.length, 1);
+    assert.strictEqual(d.data.unusedVarFix.edits[0].newText, '');
+  });
+
+  test('Detects unused variable in comma-separated local declaration', async () => {
+    const parser = await initializeMetaModelicaParser();
+    const tree = parser.parse(unusedLocalMultiDeclString);
+    const queries = new MetaModelicaQueries(parser.getLanguage());
+    const diagnostics = getDiagnosticsFromTree(tree, queries);
+
+    const unused = diagnostics.filter(d => d.message.startsWith('Unused variable'));
+    assert.strictEqual(unused.length, 1, 'Exactly one unused variable from multi-decl line');
+
+    const d = unused[0] as LSP.Diagnostic & { data: { unusedVarFix: { varName: string; edits: LSP.TextEdit[] } } };
+    assert.strictEqual(d.message, "Unused variable 'unused'.");
+    assert.strictEqual(d.data.unusedVarFix.varName, 'unused');
+    // Fix removes ", unused" from the declaration list
+    assert.strictEqual(d.data.unusedVarFix.edits.length, 1);
+    assert.strictEqual(d.data.unusedVarFix.edits[0].newText, '');
+  });
+
   test('Does not flag function-call arguments (only plain identifiers)', async () => {
     const parser = await initializeMetaModelicaParser();
     const tree = parser.parse(complexArgMatchString);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     "sourceMap": true,
     "skipLibCheck": true,
     "moduleResolution": "node",
-    "ignoreDeprecations": "6.0",
     "declaration": true,
     "strict": true, /* enable all strict type-checking options */
     /* Additional Checks */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "Node16",
     "target": "es2022",
     "lib": [
       "es2022"
@@ -10,7 +10,7 @@
     "esModuleInterop": true,
     "sourceMap": true,
     "skipLibCheck": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "declaration": true,
     "strict": true, /* enable all strict type-checking options */
     /* Additional Checks */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "sourceMap": true,
     "skipLibCheck": true,
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "declaration": true,
     "strict": true, /* enable all strict type-checking options */
     /* Additional Checks */


### PR DESCRIPTION
## Issue

Fixes #35

## Changes

- Detect unused variables diagnostics.ts: new info-level diagnostics for variables declared in `protected` sections and `local` blocks of `match`/`matchcontinue `expressions that are never referenced in the enclosing scope. Each diagnostic carries a quick-fix that removes the declaration line, or excises a single name from a comma-separated list (e.g. I`nteger a, unused;` → `Integer a;`).
- Code action extension.ts]: `onCodeAction` surfaces a _"Remove unused variable"_ quick-fix in the editor alongside the existing match-argument fix.
- CLI filter cli.ts: `--check <name>` flag (repeatable) limits which fixes are reported or applied. Available names: `unused-var`, `unused-match-arg`. Omitting `--check` keeps the existing all-checks-run behaviour.
- Tests: 4 new diagnostic unit tests (protected var, local match var, comma-separated list, negative case) and 6 new CLI tests (per-check report/fix, both-issues file, cross-check isolation).
- Docs README.md: updated usage synopsis, option table, and quick-fix reference table.