### PR TITLE
[Server] Detect and fix unnecessary output silencing (_ := expr)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,18 +120,24 @@ Found a bug or having issues? Open a
 
 ### Quick install
 
-- Run `npm install` and `npm run postinstall` in this folder.This installs all
-  necessary npm modules in both the client and server folder
+```bash
+npm install
+npm run postinstall
+npm run esbuild
+```
+
+### VS COde
+
 - Open VS Code on this folder.
-- Press Ctrl+Shift+B to start compiling the client and server.
-- Switch to the Run and Debug View in the Sidebar (Ctrl+Shift+D).
+- Press ``Ctrl+Shift+B`` to start compiling the client and server.
+- Switch to the Run and Debug View in the Sidebar (`Ctrl+Shift+D`).
 - Select `Launch Client` from the drop down (if it is not already).
-- Press ▷ to run the launch config (F5).
+- Press ▷ to run the launch config (`F5`).
 - Both build task and launch are available in [watch
   mode](https://code.visualstudio.com/docs/editor/tasks#:~:text=The%20first%20entry%20executes,the%20HelloWorld.js%20file.)
 - In the [Extension Development
   Host](https://code.visualstudio.com/api/get-started/your-first-extension#:~:text=Then%2C%20inside%20the%20editor%2C%20press%20F5.%20This%20will%20compile%20and%20run%20the%20extension%20in%20a%20new%20Extension%20Development%20Host%20window.)
-  instance of VSCode, open a document in 'metamodelica' language mode.
+  instance of VSCode, open a document in `'metamodelica'` language mode.
   - Check the console output of `MetaModelica Language Server` to see the parsed
     tree of the opened file.
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ building), the tool is available as `mmlsc`.
 | --- | --- | --- |
 | `unused-var` | Unused variable in a `protected` section or `local` block | Remove the variable declaration |
 | `unused-match-arg` | Unused `match`/`matchcontinue` argument (pattern is `_` in every case) | Remove the argument from the input tuple and all case patterns |
+| `unused-silenced-output` | Unnecessary output silencing (`_ := expr`) — the `_ :=` prefix can be omitted | Remove the `_ :=` prefix, keeping only the expression |
 
 ## Installation
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -40,11 +40,11 @@ import * as LSP from 'vscode-languageserver/node';
 
 import { initializeMetaModelicaParser } from '../server/metaModelicaParser';
 import Analyzer from '../server/analyzer';
-import { UnusedArgFix, UnusedVarFix } from '../server/diagnostics';
+import { UnusedArgFix, UnusedVarFix, SilencedOutputFix } from '../server/diagnostics';
 
-export type CheckName = 'unused-var' | 'unused-match-arg';
+export type CheckName = 'unused-var' | 'unused-match-arg' | 'unused-silenced-output';
 
-export const ALL_CHECKS: CheckName[] = ['unused-var', 'unused-match-arg'];
+export const ALL_CHECKS: CheckName[] = ['unused-var', 'unused-match-arg', 'unused-silenced-output'];
 
 export interface ProcessResult {
   filesProcessed: number;
@@ -92,12 +92,13 @@ function applyEdits(content: string, uri: string, edits: LSP.TextEdit[]): string
  * checks, or undefined if it should be skipped.
  */
 function getFixEdits(
-  data: { unusedArgFix?: UnusedArgFix; unusedVarFix?: UnusedVarFix } | undefined,
+  data: { unusedArgFix?: UnusedArgFix; unusedVarFix?: UnusedVarFix; silencedOutputFix?: SilencedOutputFix } | undefined,
   checks: Set<CheckName>,
 ): LSP.TextEdit[] | undefined {
   if (!data) { return undefined; }
   if (checks.has('unused-match-arg') && data.unusedArgFix) { return data.unusedArgFix.edits; }
   if (checks.has('unused-var') && data.unusedVarFix) { return data.unusedVarFix.edits; }
+  if (checks.has('unused-silenced-output') && data.silencedOutputFix) { return data.silencedOutputFix.edits; }
   return undefined;
 }
 
@@ -140,7 +141,7 @@ export async function processFiles(
         const doc = TextDocument.create(uri, 'metamodelica', 1, content);
         const diagnostics = analyzer.analyze(doc);
         for (const diagnostic of diagnostics) {
-          const data = diagnostic.data as { unusedArgFix?: UnusedArgFix; unusedVarFix?: UnusedVarFix } | undefined;
+          const data = diagnostic.data as { unusedArgFix?: UnusedArgFix; unusedVarFix?: UnusedVarFix; silencedOutputFix?: SilencedOutputFix } | undefined;
           const edits = getFixEdits(data, checks);
           if (edits) {
             content = applyEdits(content, uri, edits);
@@ -160,7 +161,7 @@ export async function processFiles(
       const diagnostics = analyzer.analyze(doc);
       let count = 0;
       for (const diagnostic of diagnostics) {
-        const data = diagnostic.data as { unusedArgFix?: UnusedArgFix; unusedVarFix?: UnusedVarFix } | undefined;
+        const data = diagnostic.data as { unusedArgFix?: UnusedArgFix; unusedVarFix?: UnusedVarFix; silencedOutputFix?: SilencedOutputFix } | undefined;
         if (getFixEdits(data, checks)) {
           const { line, character } = diagnostic.range.start;
           console.log(`${filePath}:${line + 1}:${character + 1}: ${diagnostic.message}`);
@@ -188,8 +189,9 @@ async function main(): Promise<void> {
       '  --check <name>   Limit to a specific check (repeatable; default: all checks)\n' +
       '  --help           Show this help\n\n' +
       '  Available check names:\n' +
-      '    unused-var         Unused protected/local variables\n' +
-      '    unused-match-arg   Unused match/matchcontinue arguments\n\n' +
+      '    unused-var              Unused protected/local variables\n' +
+      '    unused-match-arg        Unused match/matchcontinue arguments\n' +
+      '    unused-silenced-output  Unnecessary output silencing (\'_ := expr\')\n\n' +
       '  paths    Files or directories to process (.mo files, directories are scanned recursively)'
     );
     process.exit(0);

--- a/src/server/diagnostics.ts
+++ b/src/server/diagnostics.ts
@@ -50,6 +50,10 @@ export interface UnusedVarFix {
   edits: LSP.TextEdit[];
 }
 
+export interface SilencedOutputFix {
+  edits: LSP.TextEdit[];
+}
+
 /**
  * Extract tuple element expressions from a `(a, b, c)` expression node.
  * Returns null if the expression is not a parenthesized tuple with at least two elements.
@@ -320,6 +324,58 @@ function getUnusedMatchArguments(rootNode: Parser.SyntaxNode): { argNode: Parser
   return results;
 }
 
+/**
+ * Check whether a simple_expression node represents a bare wildcard `_`.
+ * Structure: simple_expression → component_reference__function_call → component_reference → WILD
+ */
+function isWildcardSimpleExpr(simpleExpr: Parser.SyntaxNode): boolean {
+  if (simpleExpr.type !== 'simple_expression') { return false; }
+  if (simpleExpr.namedChildren.length !== 1) { return false; }
+  const crf = simpleExpr.namedChildren[0];
+  if (crf.type !== 'component_reference__function_call' || crf.namedChildren.length !== 1) { return false; }
+  const cr = crf.namedChildren[0];
+  if (cr.type !== 'component_reference' || cr.namedChildren.length !== 1) { return false; }
+  return cr.namedChildren[0].type === 'WILD';
+}
+
+/**
+ * Find `_ := expr` statements in algorithm sections.  The return value of the
+ * called function is silenced unnecessarily — in MetaModelica the assignment
+ * can simply be omitted.
+ */
+function getSilencedOutputs(rootNode: Parser.SyntaxNode): { wildNode: Parser.SyntaxNode; fix: SilencedOutputFix }[] {
+  const results: { wildNode: Parser.SyntaxNode; fix: SilencedOutputFix }[] = [];
+
+  TreeSitterUtil.forEach(rootNode, (node) => {
+    if (node.type !== 'assign_clause_a') { return true; }
+
+    const lhsExpr = node.namedChildren.find(c => c.type === 'simple_expression');
+    if (!lhsExpr || !isWildcardSimpleExpr(lhsExpr)) { return true; }
+
+    const rhsExpr = node.namedChildren.find(c => c.type === 'expression');
+    if (!rhsExpr) { return true; }
+
+    // The WILD node is nested inside lhsExpr.
+    const wildNode = lhsExpr.namedChildren[0].namedChildren[0].namedChildren[0];
+
+    // Remove `_ := ` by replacing the span from the start of assign_clause_a
+    // to the start of the RHS expression with an empty string.
+    const fix: SilencedOutputFix = {
+      edits: [{
+        range: LSP.Range.create(
+          node.startPosition.row, node.startPosition.column,
+          rhsExpr.startPosition.row, rhsExpr.startPosition.column,
+        ),
+        newText: '',
+      }],
+    };
+    results.push({ wildNode, fix });
+    return true;
+  });
+
+  return results;
+}
+
 export function getDiagnosticsFromTree(tree: Parser.Tree, queries: MetaModelicaQueries): LSP.Diagnostic[] {
   const diagnostics: LSP.Diagnostic[] = [];
   let captures: Parser.QueryCapture[];
@@ -417,6 +473,17 @@ export function getDiagnosticsFromTree(tree: Parser.Tree, queries: MetaModelicaQ
       LSP.DiagnosticSeverity.Information,
       `Unused match argument '${argNode.text}': pattern is '_' in every case.`);
     (diagnostic as LSP.Diagnostic & { data: unknown }).data = { unusedArgFix: fix };
+    diagnostics.push(diagnostic);
+  }
+
+  // Inform about silenced outputs (`_ := expr`)
+  const silencedOutputs = getSilencedOutputs(tree.rootNode);
+  for (const { wildNode, fix } of silencedOutputs) {
+    const diagnostic = nodeToDiagnostic(
+      wildNode,
+      LSP.DiagnosticSeverity.Information,
+      `Unnecessary output silencing: replace '_ := expr' with just 'expr'.`);
+    (diagnostic as LSP.Diagnostic & { data: unknown }).data = { silencedOutputFix: fix };
     diagnostics.push(diagnostic);
   }
 

--- a/src/server/extension.ts
+++ b/src/server/extension.ts
@@ -45,7 +45,7 @@ import { TextDocument} from 'vscode-languageserver-textdocument';
 import { initializeMetaModelicaParser } from './metaModelicaParser';
 import Analyzer from './analyzer';
 import { logger, setLogConnection, setLogLevel } from '../util/logger';
-import { UnusedArgFix, UnusedVarFix } from './diagnostics';
+import { UnusedArgFix, UnusedVarFix, SilencedOutputFix } from './diagnostics';
 
 /**
  * MetaModelicaServer collection all the important bits and bobs.
@@ -153,7 +153,7 @@ export class MetaModelicaServer {
   private onCodeAction(params: LSP.CodeActionParams): LSP.CodeAction[] {
     const actions: LSP.CodeAction[] = [];
     for (const diagnostic of params.context.diagnostics) {
-      const data = diagnostic.data as { unusedArgFix?: UnusedArgFix; unusedVarFix?: UnusedVarFix } | undefined;
+      const data = diagnostic.data as { unusedArgFix?: UnusedArgFix; unusedVarFix?: UnusedVarFix; silencedOutputFix?: SilencedOutputFix } | undefined;
       if (data?.unusedArgFix) {
         const fix = data.unusedArgFix;
         actions.push({
@@ -172,6 +172,20 @@ export class MetaModelicaServer {
         const fix = data.unusedVarFix;
         actions.push({
           title: `Remove unused variable '${fix.varName}'`,
+          kind: LSP.CodeActionKind.QuickFix,
+          diagnostics: [diagnostic],
+          isPreferred: true,
+          edit: {
+            changes: {
+              [params.textDocument.uri]: fix.edits
+            }
+          }
+        });
+      }
+      if (data?.silencedOutputFix) {
+        const fix = data.silencedOutputFix;
+        actions.push({
+          title: `Remove unnecessary '_ :='`,
           kind: LSP.CodeActionKind.QuickFix,
           diagnostics: [diagnostic],
           isPreferred: true,

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -256,4 +256,65 @@ end foo;
     const remaining = await processFiles([filePath], false, new Set(['unused-match-arg']));
     assert.strictEqual(remaining.issuesFound, 1, 'Unused match arg should remain unfixed');
   });
+
+  // ── unused-silenced-output ─────────────────────────────────────────────────
+
+  const silencedOutputSource = `function binTreeintersection1
+  input Integer key;
+  output Integer result;
+algorithm
+  _ := someFunc(key);
+  result := key + 1;
+end binTreeintersection1;
+`;
+
+  const silencedOutputFixed = `function binTreeintersection1
+  input Integer key;
+  output Integer result;
+algorithm
+  someFunc(key);
+  result := key + 1;
+end binTreeintersection1;
+`;
+
+  test('detects silenced output (report mode)', async () => {
+    const filePath = path.join(tmpDir, 'silenced.mo');
+    fs.writeFileSync(filePath, silencedOutputSource);
+
+    const result = await processFiles([filePath], false);
+
+    assert.strictEqual(result.filesProcessed, 1);
+    assert.strictEqual(result.issuesFound, 1);
+    assert.strictEqual(result.issuesFixed, 0);
+    assert.strictEqual(fs.readFileSync(filePath, 'utf-8'), silencedOutputSource);
+  });
+
+  test('fixes silenced output in-place (fix mode)', async () => {
+    const filePath = path.join(tmpDir, 'silenced.mo');
+    fs.writeFileSync(filePath, silencedOutputSource);
+
+    const result = await processFiles([filePath], true);
+
+    assert.strictEqual(result.filesProcessed, 1);
+    assert.strictEqual(result.issuesFixed, 1);
+    assert.strictEqual(fs.readFileSync(filePath, 'utf-8'), silencedOutputFixed);
+  });
+
+  test('--check unused-silenced-output reports only silenced outputs', async () => {
+    const filePath = path.join(tmpDir, 'silenced.mo');
+    fs.writeFileSync(filePath, silencedOutputSource);
+
+    const result = await processFiles([filePath], false, new Set(['unused-silenced-output']));
+
+    assert.strictEqual(result.issuesFound, 1, 'Only the silenced-output issue should be reported');
+  });
+
+  test('--check unused-var does not report silenced outputs', async () => {
+    const filePath = path.join(tmpDir, 'silenced.mo');
+    fs.writeFileSync(filePath, silencedOutputSource);
+
+    const result = await processFiles([filePath], false, new Set(['unused-var']));
+
+    assert.strictEqual(result.issuesFound, 0, 'Silenced output should not be reported under unused-var');
+  });
 });

--- a/test/server/diagnostics.test.ts
+++ b/test/server/diagnostics.test.ts
@@ -386,4 +386,70 @@ end foo;
     const unused = diagnostics.filter(d => d.message.startsWith('Unused match argument'));
     assert.strictEqual(unused.length, 0, 'Function-call argument must not be flagged');
   });
+
+  // ── Silenced outputs (`_ := expr`) ────────────────────────────────────────
+
+  const silencedOutputString = `
+function binTreeintersection1
+  input Integer key;
+  input BinTree bt2;
+  input BinTree iBt;
+  output BinTree oBt;
+algorithm
+  oBt := matchcontinue(key,bt2,iBt)
+    local
+      BinTree bt;
+    case(_,_,_)
+      algorithm
+        _ := treeGet(bt2,key);
+        bt := treeAdd(iBt,key,0);
+      then
+        bt;
+    else iBt;
+  end matchcontinue;
+end binTreeintersection1;
+`;
+
+  const noSilencedOutputString = `
+function addOne
+  input Integer x;
+  output Integer y;
+algorithm
+  y := x + 1;
+end addOne;
+`;
+
+  test('Detects silenced output (_ := expr)', async () => {
+    const parser = await initializeMetaModelicaParser();
+    const tree = parser.parse(silencedOutputString);
+    const queries = new MetaModelicaQueries(parser.getLanguage());
+    const diagnostics = getDiagnosticsFromTree(tree, queries);
+
+    const silenced = diagnostics.filter(d => d.message.startsWith('Unnecessary output silencing'));
+    assert.strictEqual(silenced.length, 1, 'Exactly one silenced output expected');
+
+    const d = silenced[0] as LSP.Diagnostic & { data: { silencedOutputFix: { edits: LSP.TextEdit[] } } };
+    assert.strictEqual(d.severity, LSP.DiagnosticSeverity.Information);
+    assert.strictEqual(d.source, 'MetaModelica-language-server');
+    // Diagnostic points at the `_` token
+    assert.deepEqual(d.range.start, { line: 12, character: 8 });
+    assert.deepEqual(d.range.end, { line: 12, character: 9 });
+
+    // Fix removes `_ := ` (from start of statement to start of rhs expression)
+    assert.strictEqual(d.data.silencedOutputFix.edits.length, 1);
+    assert.strictEqual(d.data.silencedOutputFix.edits[0].newText, '');
+    // The edit range covers `_ := `
+    assert.deepEqual(d.data.silencedOutputFix.edits[0].range.start, { line: 12, character: 8 });
+    assert.deepEqual(d.data.silencedOutputFix.edits[0].range.end, { line: 12, character: 13 });
+  });
+
+  test('Does not flag regular assignments', async () => {
+    const parser = await initializeMetaModelicaParser();
+    const tree = parser.parse(noSilencedOutputString);
+    const queries = new MetaModelicaQueries(parser.getLanguage());
+    const diagnostics = getDiagnosticsFromTree(tree, queries);
+
+    const silenced = diagnostics.filter(d => d.message.startsWith('Unnecessary output silencing'));
+    assert.strictEqual(silenced.length, 0);
+  });
 });


### PR DESCRIPTION
## Issue
Closes #37.

## Changes

Adds a new info-level diagnostic for `_ := expr` statements in algorithm sections where the return value is discarded unnecessarily.  In MetaModelica the assignment can simply be omitted.  A quick-fix removes the `_ :=` prefix, a new CLI check `unused-silenced-output` is wired into `mmlsc --check`, and tests + README are updated.
