### PR TITLE
[Deps] Update dependencies and fix breaking API changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,12 @@ updates:
       npm-development:
         dependency-type: development
         update-types:
+          - major
           - minor
           - patch
       npm-production:
         dependency-type: production
         update-types:
+          - major
+          - minor
           - patch

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ building), the tool is available as `mmlsc`.
 ### Via VSIX File
 
 Download the latest
-[metamodelica-language-server-0.2.0.vsix](https://github.com/OpenModelica/metamodelica-language-server/releases/download/v0.2.0/metamodelica-language-server-0.2.0.vsix)
+[metamodelica-language-server-0.3.0.vsix](https://github.com/OpenModelica/metamodelica-language-server/releases/download/v0.3.0/metamodelica-language-server-0.3.0.vsix)
 from the
 [releases](https://github.com/OpenModelica/metamodelica-language-server/releases)
 page.
@@ -91,7 +91,7 @@ on how to install a .vsix file.
 Use the `Install from VSIX` command or run
 
 ```bash
-code --install-extension metamodelica-language-server-0.2.0.vsix
+code --install-extension metamodelica-language-server-0.3.0.vsix
 ```
 
 ## Contributing ❤️
@@ -116,17 +116,16 @@ Found a bug or having issues? Open a
 
 ### Dependencies
 
-- Docker installed and running.
+- Node.js >= 22
 
 ### Quick install
 
 ```bash
 npm install
-npm run postinstall
 npm run esbuild
 ```
 
-### VS COde
+### VS Code
 
 - Open VS Code on this folder.
 - Press ``Ctrl+Shift+B`` to start compiling the client and server.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,37 @@ npm run esbuild
   - Check the console output of `MetaModelica Language Server` to see the parsed
     tree of the opened file.
 
+## Testing
+
+The test suite runs inside a VS Code instance (via [`@vscode/test-electron`](https://github.com/microsoft/vscode-test)) and requires a display. It also exercises the GDB adapter, so `gdb` and `omc` must be on `PATH`.
+
+### Prerequisites
+
+- Node.js >= 22
+- `gdb`
+- `omc` (OpenModelica Compiler)
+- A display server — on a headless machine use `xvfb`
+
+### Running the tests
+
+Build the extension first, then run the suite:
+
+```bash
+npm install
+npm run esbuild
+npm test
+```
+
+On a headless machine (e.g. WSL2 without WSLg, or a CI server) provide a
+virtual display with `xvfb-run`:
+
+```bash
+sudo apt-get install -y xvfb gdb
+xvfb-run -a npm test
+```
+
+This is equivalent to what the CI workflow does.
+
 ## Build and Install Extension
 
 ```bash

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -141,11 +141,11 @@ main().catch(e => {
   process.exit(1);
 });
 
-// Copy tree-sitter.wasm and tree-sitter-metamodelica.wasm and
+// Copy web-tree-sitter.wasm and tree-sitter-metamodelica.wasm and
 // tree-sitter-gdbmi.wasm to the output directory
 if (!fs.existsSync('out')) {
   fs.mkdirSync('out');
 }
 fs.copyFileSync('./src/server/tree-sitter-metamodelica.wasm', './out/tree-sitter-metamodelica.wasm');
 fs.copyFileSync('./src/debugger/parser/tree-sitter-gdbmi.wasm', './out/tree-sitter-gdbmi.wasm');
-fs.copyFileSync('./node_modules/web-tree-sitter/tree-sitter.wasm', './out/tree-sitter.wasm');
+fs.copyFileSync('./node_modules/web-tree-sitter/web-tree-sitter.wasm', './out/web-tree-sitter.wasm');

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -40,7 +40,7 @@ async function main() {
     sourcesContent: false,
     platform: 'node',
     outfile: './out/server.js',
-    external: ['vscode'],
+    external: ['vscode', 'web-tree-sitter'],
     logLevel: 'warning',
     plugins: [
       /* add to the end of plugins array */
@@ -64,7 +64,7 @@ async function main() {
     sourcesContent: false,
     platform: 'node',
     outfile: './out/cli.js',
-    external: ['vscode'],
+    external: ['vscode', 'web-tree-sitter'],
     banner: { js: '#!/usr/bin/env node' },
     logLevel: 'warning',
     plugins: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,19 +10,20 @@
       "hasInstallScript": true,
       "license": "See OSMC-License.txt",
       "dependencies": {
-        "tree-sitter": "^0.21.1",
-        "tree-sitter-cli": "^0.23.2",
+        "tree-sitter-cli": "^0.26.9",
         "vscode-languageclient": "^9.0.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.12",
-        "web-tree-sitter": "^0.22.5"
+        "web-tree-sitter": "^0.26.9"
       },
       "bin": {
         "mmlsc": "out/cli.js"
       },
       "devDependencies": {
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "^10.0.1",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^22.13.10",
+        "@types/node": "^25.9.1",
         "@types/vscode": "^1.120.0",
         "@typescript-eslint/eslint-plugin": "^8.60.0",
         "@typescript-eslint/parser": "^8.60.0",
@@ -30,9 +31,10 @@
         "@vscode/test-electron": "^2.5.2",
         "axios": "^1.16.1",
         "esbuild": "^0.28.0",
-        "eslint": "^9.22.0",
+        "eslint": "^10.4.0",
         "glob": "^13.0.6",
-        "mocha": "^11.7.6",
+        "globals": "^17.6.0",
+        "mocha": "^11.3.0",
         "tree-sitter-gdbmi": "github:novafacing/tree-sitter-gdbmi",
         "ts-node": "^10.9.2"
       },
@@ -526,75 +528,44 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.5"
+        "minimatch": "^10.2.4"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -639,6 +610,50 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -663,40 +678,48 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@humanfs/core": {
@@ -906,6 +929,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -928,14 +958,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/vscode": {
@@ -1677,9 +1707,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
-      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -1830,34 +1860,31 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+      "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.2",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
-        "@eslint/plugin-kit": "^0.4.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "ajv": "^6.14.0",
-        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -1867,8 +1894,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.5",
+        "minimatch": "^10.2.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -1876,7 +1902,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -1891,17 +1917,19 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -1920,32 +1948,14 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -1961,45 +1971,32 @@
         "node": ">= 4"
       }
     },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "eslint-visitor-keys": "^5.0.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -2310,9 +2307,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2522,16 +2519,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -2682,13 +2669,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -2796,30 +2776,29 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.6",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
-      "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.3.0.tgz",
+      "integrity": "sha512-J0RLIM89xi8y6l77bgbX+03PeBRDQCOVQpnwOcCN7b8hCmbh6JvGI2ZDJ5WMoHz+IaPU+S4lvTd0j51GmBAdgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "browser-stdout": "^1.3.1",
         "chokidar": "^4.0.1",
         "debug": "^4.3.5",
-        "diff": "^7.0.0",
+        "diff": "^5.2.0",
         "escape-string-regexp": "^4.0.0",
         "find-up": "^5.0.0",
         "glob": "^10.4.5",
         "he": "^1.2.0",
-        "is-path-inside": "^3.0.3",
         "js-yaml": "^4.1.0",
         "log-symbols": "^4.1.0",
-        "minimatch": "^9.0.5",
+        "minimatch": "^5.1.6",
         "ms": "^2.1.3",
         "picocolors": "^1.1.1",
         "serialize-javascript": "^6.0.2",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
-        "workerpool": "^9.2.0",
+        "workerpool": "^6.5.1",
         "yargs": "^17.7.2",
         "yargs-parser": "^21.1.1",
         "yargs-unparser": "^2.0.0"
@@ -2871,14 +2850,7 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/mocha/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/mocha/node_modules/minimatch": {
+    "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
@@ -2892,6 +2864,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mocha/node_modules/path-scurry": {
@@ -2947,26 +2939,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/node-addon-api": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
-      "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "license": "MIT",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
     },
     "node_modules/onetime": {
       "version": "7.0.0",
@@ -3545,21 +3517,10 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tree-sitter": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
-      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^8.0.0",
-        "node-gyp-build": "^4.8.0"
-      }
-    },
     "node_modules/tree-sitter-cli": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.23.2.tgz",
-      "integrity": "sha512-kPPXprOqREX+C/FgUp2Qpt9jd0vSwn+hOgjzVv/7hapdoWpa+VeWId53rf4oNNd29ikheF12BYtGD/W90feMbA==",
+      "version": "0.26.9",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.26.9.tgz",
+      "integrity": "sha512-7l+U1RmazPVe+yA/JiX80GFOILnL/j24GbawamIzNQC8UlINrcyECbaWGaG1wuq4j/m0DQTx7Uu4r0iW9Ao1BQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -3635,6 +3596,16 @@
         }
       }
     },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3664,9 +3635,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3779,9 +3750,9 @@
       "license": "MIT"
     },
     "node_modules/web-tree-sitter": {
-      "version": "0.22.6",
-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.22.6.tgz",
-      "integrity": "sha512-hS87TH71Zd6mGAmYCvlgxeGDjqd9GTeqXNqTT+u0Gs51uIozNIaaq/kUAbV/Zf56jb2ZOyG8BxZs2GG9wbLi6Q==",
+      "version": "0.26.9",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.9.tgz",
+      "integrity": "sha512-YJwSHANl6XFgeEjB8nitgj0qZYt5gkIesJ4w2srS2wcLB4GUa4xcOkM0YaMsU6WNR53YVIkDSY7Ej4pf3IXtCA==",
       "license": "MIT"
     },
     "node_modules/which": {
@@ -3811,9 +3782,9 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "9.3.4",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
-      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
       "dev": true,
       "license": "Apache-2.0"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -542,6 +542,45 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@eslint/config-helpers": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
@@ -592,55 +631,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -652,29 +642,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@eslint/js": {
@@ -1004,6 +971,16 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.60.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.0.tgz",
@@ -1152,6 +1129,45 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/utils": {
@@ -1401,26 +1417,20 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/browser-stdout": {
@@ -1482,6 +1492,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/chokidar": {
@@ -1707,9 +1730,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
-      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -1948,6 +1971,29 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
@@ -1961,17 +2007,7 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/espree": {
+    "node_modules/eslint/node_modules/espree": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
       "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
@@ -1989,14 +2025,48 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -2306,6 +2376,45 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/globals": {
       "version": "17.6.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
@@ -2423,9 +2532,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2517,6 +2626,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-plain-obj": {
@@ -2750,19 +2869,16 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^1.1.7"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": "*"
       }
     },
     "node_modules/minipass": {
@@ -2776,29 +2892,30 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.3.0.tgz",
-      "integrity": "sha512-J0RLIM89xi8y6l77bgbX+03PeBRDQCOVQpnwOcCN7b8hCmbh6JvGI2ZDJ5WMoHz+IaPU+S4lvTd0j51GmBAdgQ==",
+      "version": "11.7.6",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
+      "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "browser-stdout": "^1.3.1",
         "chokidar": "^4.0.1",
         "debug": "^4.3.5",
-        "diff": "^5.2.0",
+        "diff": "^7.0.0",
         "escape-string-regexp": "^4.0.0",
         "find-up": "^5.0.0",
         "glob": "^10.4.5",
         "he": "^1.2.0",
+        "is-path-inside": "^3.0.3",
         "js-yaml": "^4.1.0",
         "log-symbols": "^4.1.0",
-        "minimatch": "^5.1.6",
+        "minimatch": "^9.0.5",
         "ms": "^2.1.3",
         "picocolors": "^1.1.1",
         "serialize-javascript": "^6.0.2",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
-        "workerpool": "^6.5.1",
+        "workerpool": "^9.2.0",
         "yargs": "^17.7.2",
         "yargs-parser": "^21.1.1",
         "yargs-unparser": "^2.0.0"
@@ -2810,13 +2927,6 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
-    },
-    "node_modules/mocha/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/mocha/node_modules/brace-expansion": {
       "version": "2.1.1",
@@ -2850,7 +2960,14 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
+    "node_modules/mocha/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/mocha/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
@@ -2864,26 +2981,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mocha/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/mocha/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/mocha/node_modules/path-scurry": {
@@ -2901,22 +2998,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mocha/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/ms": {
@@ -3488,16 +3569,19 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/tinyglobby": {
@@ -3688,12 +3772,6 @@
         "vscode": "^1.82.0"
       }
     },
-    "node_modules/vscode-languageclient/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
     "node_modules/vscode-languageclient/node_modules/brace-expansion": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
@@ -3782,9 +3860,9 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
-      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
       "dev": true,
       "license": "Apache-2.0"
     },

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "test-compile": "tsc -b ./",
     "lint": "eslint ./src/** ./test/** --ext .ts,.tsx",
     "tree-sitter-metamodelica": "cd src/server && node tree.sitter.metamodelica.download.js",
-    "tree-sitter-gdbmi": "cd src/debugger/parser && node tree.sitter.gdbmi.js",
+    "tree-sitter-gdbmi": "tree-sitter build --wasm --output src/debugger/parser/tree-sitter-gdbmi.wasm node_modules/tree-sitter-gdbmi",
     "postinstall": "npm run tree-sitter-metamodelica && npm run tree-sitter-gdbmi",
     "test": "npm run test-compile && node ./dist/test/runTest",
     "all": "npm run postinstall && npm run esbuild && npm run lint && npm run test && npm run vscode:prepublish"

--- a/package.json
+++ b/package.json
@@ -76,7 +76,9 @@
                   "type": "string"
                 },
                 "description": "Arguments to omc. e.g., MOS file",
-                "default": ["script.mos"]
+                "default": [
+                  "script.mos"
+                ]
               },
               "cwd": {
                 "type": "string",
@@ -87,7 +89,13 @@
                 "type": "string",
                 "description": "Logging level for the debugger",
                 "default": "warning",
-                "enum": ["debug", "log", "info", "warning", "error"]
+                "enum": [
+                  "debug",
+                  "log",
+                  "info",
+                  "warning",
+                  "error"
+                ]
               }
             }
           }
@@ -99,7 +107,9 @@
             "request": "launch",
             "gdb": "gdb",
             "program": "omc",
-            "arguments": ["script.mos"],
+            "arguments": [
+              "script.mos"
+            ],
             "cwd": "${workspaceFolder}",
             "logLevel": "info"
           }
@@ -114,7 +124,9 @@
               "request": "launch",
               "gdb": "gdb",
               "program": "omc",
-              "arguments": ["script.mos"],
+              "arguments": [
+                "script.mos"
+              ],
               "cwd": "${workspaceFolder}",
               "logLevel": "info"
             }
@@ -133,37 +145,38 @@
     "test-compile": "tsc -b ./",
     "lint": "eslint ./src/** ./test/** --ext .ts,.tsx",
     "tree-sitter-metamodelica": "cd src/server && node tree.sitter.metamodelica.download.js",
-    "tree-sitter-gdbmi": "cd node_modules/tree-sitter-gdbmi && ../../node_modules/.bin/tree-sitter generate && ../../node_modules/.bin/tree-sitter build --wasm --docker . && cd ../../src/debugger/parser && node tree.sitter.gdbmi.js",
+    "tree-sitter-gdbmi": "cd src/debugger/parser && node tree.sitter.gdbmi.js",
     "postinstall": "npm run tree-sitter-metamodelica && npm run tree-sitter-gdbmi",
     "test": "npm run test-compile && node ./dist/test/runTest",
     "all": "npm run postinstall && npm run esbuild && npm run lint && npm run test && npm run vscode:prepublish"
   },
-  "overrides": {
-    "diff": "^9.0.0",
-    "serialize-javascript": "^7.0.5"
-  },
   "dependencies": {
+    "tree-sitter-cli": "^0.26.9",
     "vscode-languageclient": "^9.0.1",
-    "tree-sitter": "^0.21.1",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.12",
-    "web-tree-sitter": "^0.22.5",
-    "tree-sitter-cli": "^0.23.2"
+    "web-tree-sitter": "^0.26.9"
+  },
+  "overrides": {
+    "serialize-javascript": "^7.0.5"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.3.5",
+    "@eslint/js": "^10.0.1",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^22.13.10",
+    "@types/node": "^25.9.1",
+    "@types/vscode": "^1.120.0",
     "@typescript-eslint/eslint-plugin": "^8.60.0",
     "@typescript-eslint/parser": "^8.60.0",
-    "esbuild": "^0.28.0",
-    "eslint": "^9.22.0",
-    "mocha": "^11.7.6",
-    "ts-node": "^10.9.2",
-    "@types/vscode": "^1.120.0",
-    "@vscode/test-electron": "^2.5.2",
-    "glob": "^13.0.6",
-    "axios": "^1.16.1",
     "@vscode/debugadapter": "^1.68.0",
-    "tree-sitter-gdbmi": "github:novafacing/tree-sitter-gdbmi"
+    "@vscode/test-electron": "^2.5.2",
+    "axios": "^1.16.1",
+    "esbuild": "^0.28.0",
+    "eslint": "^10.4.0",
+    "glob": "^13.0.6",
+    "globals": "^17.6.0",
+    "mocha": "^11.3.0",
+    "tree-sitter-gdbmi": "github:novafacing/tree-sitter-gdbmi",
+    "ts-node": "^10.9.2"
   }
 }

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -102,7 +102,7 @@ export async function activate(context: ExtensionContext) {
   );
 
   // Start the client. This will also launch the server
-  client.start();
+  await client.start();
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -45,7 +45,6 @@ import {
 import * as DebuggerExtension from '../debugger/extension';
 
 let client: LanguageClient;
-let metaModelicaDebugger: any;
 
 export async function activate(context: ExtensionContext) {
   // Activate Debugger
@@ -109,9 +108,6 @@ export async function activate(context: ExtensionContext) {
 export function deactivate(): Thenable<void> | undefined {
   if (!client) {
     return undefined;
-  }
-  if (metaModelicaDebugger) {
-    metaModelicaDebugger.deactivate();
   }
   return client.stop();
 }

--- a/src/debugger/parser/gdbParser.ts
+++ b/src/debugger/parser/gdbParser.ts
@@ -33,7 +33,7 @@
  *
  */
 
-import Parser from 'web-tree-sitter';
+import { Parser, Language, Tree, Node as SyntaxNode } from 'web-tree-sitter';
 import * as fs from 'fs';
 import * as path from 'path';
 import { logger } from '../../util/logger';
@@ -112,7 +112,7 @@ export interface GDBMIList {
 
 export class GDBMIParser {
   private parser: Parser | undefined = undefined;
-  private tree: Parser.Tree | undefined = undefined;
+  private tree: Tree | undefined = undefined;
 
   async initialize() {
     this.parser = await initializeGdbMiParser();
@@ -123,7 +123,7 @@ export class GDBMIParser {
       throw new Error("GDB/MI parser undefined. Call initialize first.");
     }
 
-    this.tree = this.parser!.parse(input);
+    this.tree = this.parser!.parse(input)!;
     // walkTree and print it for debugging purpose
     this.walkTree(this.tree.rootNode);
     // return GDBMIOutput
@@ -137,7 +137,7 @@ export class GDBMIParser {
    * @param node - The current syntax node to process.
    * @param depth - The current depth in the tree, used for indentation. Defaults to 0.
    */
-  private walkTree(node: Parser.SyntaxNode, depth: number = 0) {
+  private walkTree(node: SyntaxNode, depth: number = 0) {
     const indent = '  '.repeat(depth);
     logger.debug(`${indent}${node.type}: ${node.text}`);
 
@@ -224,7 +224,7 @@ export class GDBMIParser {
    * - 'ConsoleStreamOutput': Assigns the text of the node to the `consoleStreamOutput` property.
    * - 'LogStreamOutput': Assigns the text of the node to the `logStreamOutput` property.
    */
-  private parseResultRecord(node: Parser.SyntaxNode): GDBMIResultRecord {
+  private parseResultRecord(node: SyntaxNode): GDBMIResultRecord {
     const resultRecord: GDBMIResultRecord = {
       token: 0,
       cls: '',
@@ -271,7 +271,7 @@ export class GDBMIParser {
    * @param node - The SyntaxNode to be parsed.
    * @returns A GDBMIOutOfBandRecord object containing the parsed information.
    */
-  private parseOutOfBandRecord(node: Parser.SyntaxNode): GDBMIOutOfBandRecord {
+  private parseOutOfBandRecord(node: SyntaxNode): GDBMIOutOfBandRecord {
     const outOfBandRecord: GDBMIOutOfBandRecord = {};
 
     for (let i = 0; i < node.childCount; i++) {
@@ -304,7 +304,7 @@ export class GDBMIParser {
    * based on the type of each child node. The possible types are 'ExecAsyncOutput',
    * 'StatusAsyncOutput', and 'NotifyAsyncOutput'.
    */
-  private parseAsyncRecord(node: Parser.SyntaxNode): GDBMIAsyncRecord {
+  private parseAsyncRecord(node: SyntaxNode): GDBMIAsyncRecord {
     const asyncRecord: GDBMIAsyncRecord = {};
 
     for (let i = 0; i < node.childCount; i++) {
@@ -335,7 +335,7 @@ export class GDBMIParser {
    * @param node - The syntax node to parse.
    * @returns A `GDBMIExecAsyncOutput` object containing the parsed exec async output.
    */
-  private parseExecAsynOutput(node: Parser.SyntaxNode): GDBMIExecAsyncOutput {
+  private parseExecAsynOutput(node: SyntaxNode): GDBMIExecAsyncOutput {
     const execAsyncOutput: GDBMIExecAsyncOutput = {};
 
     for (let i = 0; i < node.childCount; i++) {
@@ -360,7 +360,7 @@ export class GDBMIParser {
    * @param node - The syntax node to parse.
    * @returns A `GDBMIStatusAsyncOutput` object containing the parsed status async output.
    */
-  private parseStatusAsyncOutput(node: Parser.SyntaxNode): GDBMIStatusAsyncOutput {
+  private parseStatusAsyncOutput(node: SyntaxNode): GDBMIStatusAsyncOutput {
     const statusAsyncOutput: GDBMIStatusAsyncOutput = {};
 
     for (let i = 0; i < node.childCount; i++) {
@@ -385,7 +385,7 @@ export class GDBMIParser {
    * @param node - The syntax node to parse.
    * @returns A `GDBMINotifyAsyncOutput` object containing the parsed notify async output.
    */
-  private parseNotifyAsyncOutput(node: Parser.SyntaxNode): GDBMINotifyAsyncOutput {
+  private parseNotifyAsyncOutput(node: SyntaxNode): GDBMINotifyAsyncOutput {
     const notifyAsyncOutput: GDBMINotifyAsyncOutput = {};
 
     for (let i = 0; i < node.childCount; i++) {
@@ -410,7 +410,7 @@ export class GDBMIParser {
    * @param node - The syntax node to parse.
    * @returns A `GDBMIAsyncOutput` object containing the parsed async output.
    */
-  private parseAsyncOutput(node: Parser.SyntaxNode): GDBMIAsyncOutput {
+  private parseAsyncOutput(node: SyntaxNode): GDBMIAsyncOutput {
     const asyncOutput: GDBMIAsyncOutput = {
       asyncClass: '',
       miResult: []
@@ -444,7 +444,7 @@ export class GDBMIParser {
    * @param node - The syntax node to parse.
    * @returns A GDBMIResult object containing the parsed variable and value.
    */
-  private parseResult(node: Parser.SyntaxNode): GDBMIResult {
+  private parseResult(node: SyntaxNode): GDBMIResult {
     const result: GDBMIResult = {
       variable: '',
       miValue: {
@@ -481,7 +481,7 @@ export class GDBMIParser {
    * @param node - The syntax node to parse.
    * @returns A GDBMIValue object representing the parsed value.
    */
-  private parseValue(node: Parser.SyntaxNode): GDBMIValue {
+  private parseValue(node: SyntaxNode): GDBMIValue {
     const value: GDBMIValue = {
       value: ''
     };
@@ -514,7 +514,7 @@ export class GDBMIParser {
    * @param node - The SyntaxNode to parse, which should represent a GDB/MI tuple.
    * @returns A GDBMITuple object containing the parsed results.
    */
-  private parseTuple(node: Parser.SyntaxNode): GDBMITuple {
+  private parseTuple(node: SyntaxNode): GDBMITuple {
     const tuple: GDBMITuple = {
       miResultsList: []
     };
@@ -535,7 +535,7 @@ export class GDBMIParser {
    * @param node - The syntax node representing the list to be parsed.
    * @returns A GDBMIList object containing the parsed values and results.
    */
-  private parseList(node: Parser.SyntaxNode): GDBMIList {
+  private parseList(node: SyntaxNode): GDBMIList {
     const list: GDBMIList = {
       miValuesList: [],
       miResultsList: []
@@ -571,7 +571,7 @@ export class GDBMIParser {
    * based on the type of each child node. The possible types are 'ConsoleStream',
    * 'TargetStream', and 'LogStream'.
    */
-  private parseStreamRecord(node: Parser.SyntaxNode): GDBMIStreamRecord {
+  private parseStreamRecord(node: SyntaxNode): GDBMIStreamRecord {
     const streamRecord: GDBMIStreamRecord = {
       type: GDBMIStreamRecordType.consoleStream,
       value: ''
@@ -613,7 +613,7 @@ export class GDBMIParser {
  * @returns tree-sitter-gdbmi parser
  */
 export async function initializeGdbMiParser(): Promise<Parser> {
-  await Parser.init();
+  await Parser.init({ locateFile: () => path.join(__dirname, 'web-tree-sitter.wasm') });
   const parser = new Parser;
 
   const gdbmiWasmFile = path.join(__dirname, 'tree-sitter-gdbmi.wasm');
@@ -621,7 +621,7 @@ export async function initializeGdbMiParser(): Promise<Parser> {
     throw new Error(`Can't find 'tree-sitter-gdbmi.wasm' at ${gdbmiWasmFile}`);
   }
 
-  const gdbmi = await Parser.Language.load(gdbmiWasmFile);
+  const gdbmi = await Language.load(gdbmiWasmFile);
   parser.setLanguage(gdbmi);
 
   return parser;

--- a/src/debugger/parser/gdbParser.ts
+++ b/src/debugger/parser/gdbParser.ts
@@ -613,7 +613,7 @@ export class GDBMIParser {
  * @returns tree-sitter-gdbmi parser
  */
 export async function initializeGdbMiParser(): Promise<Parser> {
-  await Parser.init({ locateFile: () => path.join(__dirname, 'web-tree-sitter.wasm') });
+  await Parser.init();
   const parser = new Parser;
 
   const gdbmiWasmFile = path.join(__dirname, 'tree-sitter-gdbmi.wasm');

--- a/src/server/analyzer.ts
+++ b/src/server/analyzer.ts
@@ -42,7 +42,7 @@
 import * as LSP from 'vscode-languageserver/node';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
-import Parser from 'web-tree-sitter';
+import { Parser, Language, Tree, Query, Node as SyntaxNode } from 'web-tree-sitter';
 
 import { getAllDeclarationsInTree } from './declarations';
 import { getDiagnosticsFromTree } from './diagnostics';
@@ -51,32 +51,32 @@ import { logger } from '../util/logger';
 type AnalyzedDocument = {
   document: TextDocument,
   declarations: LSP.DocumentSymbol[],
-  tree: Parser.Tree
+  tree: Tree
 };
 
 export class MetaModelicaQueries {
-  public identifier: Parser.Query;
-  public classType: Parser.Query;
-  public error: Parser.Query;
-  public illegalEquals: Parser.Query;
-  public illegalAssign: Parser.Query;
-  public modifierAssign: Parser.Query;
-  public caseEquation: Parser.Query;
-  public missingElseCaseMatch: Parser.Query;
-  public matchcontinue: Parser.Query;
-  public startEndIdent: Parser.Query;
+  public identifier: Query;
+  public classType: Query;
+  public error: Query;
+  public illegalEquals: Query;
+  public illegalAssign: Query;
+  public modifierAssign: Query;
+  public caseEquation: Query;
+  public missingElseCaseMatch: Query;
+  public matchcontinue: Query;
+  public startEndIdent: Query;
 
-  constructor(language: Parser.Language) {
-    this.identifier = language.query('(IDENT) @identifier');
-    this.classType = language.query('(class_type) @type');
-    this.error = language.query('(ERROR) @error');
-    this.illegalEquals = language.query('(assign_clause_a (simple_expression) (EQUALS) @error )');
-    this.illegalAssign = language.query('[ ( equation (simple_expression) (ASSIGN) @error ) ( constraint (simple_expression) (ASSIGN) @error ) ]');
-    this.modifierAssign = language.query('(modification (ASSIGN) @warning)');
-    this.caseEquation = language.query('(onecase (EQUATION) @info)');
-    this.missingElseCaseMatch = language.query('(match_expression [(MATCH) (MATCHCONTINUE)] @info (cases case: (onecase)* case: (onecase) . ))');
-    this.matchcontinue = language.query('(match_expression . (MATCHCONTINUE) @info (expression) )');
-    this.startEndIdent = language.query('(class_specifier identifier: (identifier) @start endIdentifier: (identifier) @end )');
+  constructor(language: Language) {
+    this.identifier = new Query(language, '(IDENT) @identifier');
+    this.classType = new Query(language, '(class_type) @type');
+    this.error = new Query(language, '(ERROR) @error');
+    this.illegalEquals = new Query(language, '(assign_clause_a (simple_expression) (EQUALS) @error )');
+    this.illegalAssign = new Query(language, '[ ( equation (simple_expression) (ASSIGN) @error ) ( constraint (simple_expression) (ASSIGN) @error ) ]');
+    this.modifierAssign = new Query(language, '(modification (ASSIGN) @warning)');
+    this.caseEquation = new Query(language, '(onecase (EQUATION) @info)');
+    this.missingElseCaseMatch = new Query(language, '(match_expression [(MATCH) (MATCHCONTINUE)] @info (cases case: (onecase)* case: (onecase) . ))');
+    this.matchcontinue = new Query(language, '(match_expression . (MATCHCONTINUE) @info (expression) )');
+    this.startEndIdent = new Query(language, '(class_specifier identifier: (identifier) @start endIdentifier: (identifier) @end )');
   }
 
   /**
@@ -85,7 +85,7 @@ export class MetaModelicaQueries {
    * @param node Node.
    * @returns Identifier
    */
-  public getIdentifier(node: Parser.SyntaxNode): string | undefined {
+  public getIdentifier(node: SyntaxNode): string | undefined {
     const captures = this.identifier.captures(node);
     if (captures.length > 0) {
       return captures[0].node.text;
@@ -100,7 +100,7 @@ export class MetaModelicaQueries {
    * @param node Node.
    * @returns Class type
    */
-  public getClassType(node: Parser.SyntaxNode): string | undefined {
+  public getClassType(node: SyntaxNode): string | undefined {
     const captures = this.classType.captures(node);
     if (captures.length > 0) {
       return captures[0].node.text;
@@ -117,7 +117,7 @@ export default class Analyzer {
 
   constructor (parser: Parser) {
     this.parser = parser;
-    this.queries = new MetaModelicaQueries(parser.getLanguage());
+    this.queries = new MetaModelicaQueries(parser.language!);
   }
 
   public analyze(document: TextDocument): LSP.Diagnostic[] {
@@ -126,7 +126,7 @@ export default class Analyzer {
     const fileContent = document.getText();
     const uri = document.uri;
 
-    const tree = this.parser.parse(fileContent);
+    const tree = this.parser.parse(fileContent)!;
     logger.debug(tree.rootNode.toString());
 
     // Get declarations

--- a/src/server/declarations.ts
+++ b/src/server/declarations.ts
@@ -117,7 +117,7 @@ export function getAllDeclarationsInTree(tree: Parser.Tree, queries: MetaModelic
  * @param children  DocumentSymbol children.
  * @returns         Symbol information from node.
  */
-export function nodeToDocumentSymbol(node: Parser.SyntaxNode, queries: MetaModelicaQueries, children: LSP.DocumentSymbol[] ): LSP.DocumentSymbol | null {
+export function nodeToDocumentSymbol(node: Parser.Node, queries: MetaModelicaQueries, children: LSP.DocumentSymbol[] ): LSP.DocumentSymbol | null {
   const name = queries.getIdentifier(node);
   if (name === undefined || isEmpty(name)) {
     return null;
@@ -156,7 +156,7 @@ export function nodeToDocumentSymbol(node: Parser.SyntaxNode, queries: MetaModel
  * @param node Node containing class_definition
  * @returns Symbol kind or `undefined`.
  */
-function getKind(node: Parser.SyntaxNode, queries: MetaModelicaQueries): LSP.SymbolKind | undefined {
+function getKind(node: Parser.Node, queries: MetaModelicaQueries): LSP.SymbolKind | undefined {
 
   const classType = queries.getClassType(node);
   if (classType === undefined) {

--- a/src/server/diagnostics.ts
+++ b/src/server/diagnostics.ts
@@ -58,7 +58,7 @@ export interface SilencedOutputFix {
  * Extract tuple element expressions from a `(a, b, c)` expression node.
  * Returns null if the expression is not a parenthesized tuple with at least two elements.
  */
-function getTupleInfo(expr: Parser.SyntaxNode): { inner: Parser.SyntaxNode; elements: Parser.SyntaxNode[] } | null {
+function getTupleInfo(expr: Parser.Node): { inner: Parser.Node; elements: Parser.Node[] } | null {
   // A tuple expression `(a, b, c)` parses as:
   //   expression -> simple_expression -> LPAR expression COMMA expression ... RPAR
   const inner = expr.namedChildren.find(c => c.type === 'simple_expression');
@@ -80,7 +80,7 @@ function getTupleInfo(expr: Parser.SyntaxNode): { inner: Parser.SyntaxNode; elem
  * as function calls (`f(x)`) or qualified names (`Foo.bar`) must not be removed
  * because they may carry information or have side-effects.
  */
-function isSimpleIdentifier(node: Parser.SyntaxNode): boolean {
+function isSimpleIdentifier(node: Parser.Node): boolean {
   // expression → simple_expression → component_reference__function_call → component_reference → IDENT
   const se = node.namedChildren.find(c => c.type === 'simple_expression');
   if (!se || se.namedChildren.length !== 1) { return false; }
@@ -95,7 +95,7 @@ function isSimpleIdentifier(node: Parser.SyntaxNode): boolean {
  * Build replacement text for a tuple after removing one element.
  * With one element remaining the outer parentheses are dropped.
  */
-function buildTupleNewText(elements: Parser.SyntaxNode[], skipIndex: number): string {
+function buildTupleNewText(elements: Parser.Node[], skipIndex: number): string {
   const remaining = elements.filter((_, i) => i !== skipIndex).map(e => e.text);
   if (remaining.length === 1) { return remaining[0]; }
   return '(' + remaining.join(', ') + ')';
@@ -105,7 +105,7 @@ function buildTupleNewText(elements: Parser.SyntaxNode[], skipIndex: number): st
  * Get the IDENT node from a component_declaration node.
  * In the grammar: component_declaration → declaration → IDENT (field: identifier)
  */
-function getDeclIdent(decl: Parser.SyntaxNode): Parser.SyntaxNode | null {
+function getDeclIdent(decl: Parser.Node): Parser.Node | null {
   const declNode = decl.namedChildren.find(c => c.type === 'declaration');
   if (!declNode) { return null; }
   return declNode.namedChildren.find(c => c.type === 'IDENT') || null;
@@ -115,12 +115,12 @@ function getDeclIdent(decl: Parser.SyntaxNode): Parser.SyntaxNode | null {
  * Return true if `name` appears as any IDENT node inside `scope`,
  * excluding the subtree rooted at `skipNode` (the declaration element).
  */
-function isNameUsed(name: string, scope: Parser.SyntaxNode, skipNode: Parser.SyntaxNode): boolean {
+function isNameUsed(name: string, scope: Parser.Node, skipNode: Parser.Node): boolean {
   let found = false;
   const skipStart = skipNode.startIndex;
   const skipEnd = skipNode.endIndex;
 
-  function visit(node: Parser.SyntaxNode): void {
+  function visit(node: Parser.Node): void {
     if (found) { return; }
     if (node.startIndex === skipStart && node.endIndex === skipEnd) { return; }
     if (node.type === 'IDENT' && node.text === name) {
@@ -144,9 +144,9 @@ function isNameUsed(name: string, scope: Parser.SyntaxNode, skipNode: Parser.Syn
  * list.
  */
 function buildVarRemoveEdits(
-  elementNode: Parser.SyntaxNode,
-  componentClause: Parser.SyntaxNode,
-  targetDecl: Parser.SyntaxNode,
+  elementNode: Parser.Node,
+  componentClause: Parser.Node,
+  targetDecl: Parser.Node,
 ): LSP.TextEdit[] {
   const declarations = componentClause.namedChildren.filter(c => c.type === 'component_declaration');
 
@@ -180,7 +180,7 @@ function buildVarRemoveEdits(
     }];
   } else {
     // Last: remove ", name" by spanning back to the preceding COMMA
-    let commaNode: Parser.SyntaxNode | null = null;
+    let commaNode: Parser.Node | null = null;
     for (let i = nodeIdx - 1; i >= 0; i--) {
       if (allChildren[i].type === 'COMMA') {
         commaNode = allChildren[i];
@@ -204,9 +204,9 @@ function buildVarRemoveEdits(
  * Check all component_declarations within an element node for unused variables.
  */
 function checkElementDeclarations(
-  elementNode: Parser.SyntaxNode,
-  scope: Parser.SyntaxNode,
-  results: { varNode: Parser.SyntaxNode; fix: UnusedVarFix }[],
+  elementNode: Parser.Node,
+  scope: Parser.Node,
+  results: { varNode: Parser.Node; fix: UnusedVarFix }[],
 ): void {
   const componentClause = elementNode.namedChildren.find(c => c.type === 'component_clause');
   if (!componentClause) { return; }
@@ -232,8 +232,8 @@ function checkElementDeclarations(
  * Find unused protected variables in function bodies and unused local
  * variables inside match/matchcontinue expressions.
  */
-function getUnusedVariables(rootNode: Parser.SyntaxNode): { varNode: Parser.SyntaxNode; fix: UnusedVarFix }[] {
-  const results: { varNode: Parser.SyntaxNode; fix: UnusedVarFix }[] = [];
+function getUnusedVariables(rootNode: Parser.Node): { varNode: Parser.Node; fix: UnusedVarFix }[] {
+  const results: { varNode: Parser.Node; fix: UnusedVarFix }[] = [];
 
   TreeSitterUtil.forEach(rootNode, (node) => {
     // Protected variables declared inside a composition (function body)
@@ -270,8 +270,8 @@ function getUnusedVariables(rootNode: Parser.SyntaxNode): { varNode: Parser.Synt
  * Find arguments of a `match`/`matchcontinue` that are a plain identifier and
  * matched by `_` in every case branch, and are therefore unused.
  */
-function getUnusedMatchArguments(rootNode: Parser.SyntaxNode): { argNode: Parser.SyntaxNode; fix: UnusedArgFix }[] {
-  const results: { argNode: Parser.SyntaxNode; fix: UnusedArgFix }[] = [];
+function getUnusedMatchArguments(rootNode: Parser.Node): { argNode: Parser.Node; fix: UnusedArgFix }[] {
+  const results: { argNode: Parser.Node; fix: UnusedArgFix }[] = [];
 
   TreeSitterUtil.forEach(rootNode, (node) => {
     if (node.type !== 'match_expression') {
@@ -292,7 +292,7 @@ function getUnusedMatchArguments(rootNode: Parser.SyntaxNode): { argNode: Parser
     const onecases = casesNode.namedChildren.filter(c => c.type === 'onecase');
     if (onecases.length === 0) { return true; }
 
-    const caseInfos: { inner: Parser.SyntaxNode; elements: Parser.SyntaxNode[] }[] = [];
+    const caseInfos: { inner: Parser.Node; elements: Parser.Node[] }[] = [];
     for (const onecase of onecases) {
       const patternExpr = onecase.namedChildren.find(c => c.type === 'expression');
       if (!patternExpr) { return true; }
@@ -328,7 +328,7 @@ function getUnusedMatchArguments(rootNode: Parser.SyntaxNode): { argNode: Parser
  * Check whether a simple_expression node represents a bare wildcard `_`.
  * Structure: simple_expression → component_reference__function_call → component_reference → WILD
  */
-function isWildcardSimpleExpr(simpleExpr: Parser.SyntaxNode): boolean {
+function isWildcardSimpleExpr(simpleExpr: Parser.Node): boolean {
   if (simpleExpr.type !== 'simple_expression') { return false; }
   if (simpleExpr.namedChildren.length !== 1) { return false; }
   const crf = simpleExpr.namedChildren[0];
@@ -343,8 +343,8 @@ function isWildcardSimpleExpr(simpleExpr: Parser.SyntaxNode): boolean {
  * called function is silenced unnecessarily — in MetaModelica the assignment
  * can simply be omitted.
  */
-function getSilencedOutputs(rootNode: Parser.SyntaxNode): { wildNode: Parser.SyntaxNode; fix: SilencedOutputFix }[] {
-  const results: { wildNode: Parser.SyntaxNode; fix: SilencedOutputFix }[] = [];
+function getSilencedOutputs(rootNode: Parser.Node): { wildNode: Parser.Node; fix: SilencedOutputFix }[] {
+  const results: { wildNode: Parser.Node; fix: SilencedOutputFix }[] = [];
 
   TreeSitterUtil.forEach(rootNode, (node) => {
     if (node.type !== 'assign_clause_a') { return true; }
@@ -493,7 +493,7 @@ export function getDiagnosticsFromTree(tree: Parser.Tree, queries: MetaModelicaQ
   if (matches.length > 0) {
     for (const match of matches ) {
 
-      logger.debug("pattern: " + match.pattern.toString());
+      logger.debug("pattern: " + match.patternIndex.toString());
 
       const startNode = match.captures[0].node;
       const startIdent = startNode.text;
@@ -518,7 +518,7 @@ export function getDiagnosticsFromTree(tree: Parser.Tree, queries: MetaModelicaQ
  * @param node  Syntax node
  * @returns     Diagnostic
  */
-function nodeToDiagnostic(node: Parser.SyntaxNode, severity: LSP.DiagnosticSeverity, message: string): LSP.Diagnostic {
+function nodeToDiagnostic(node: Parser.Node, severity: LSP.DiagnosticSeverity, message: string): LSP.Diagnostic {
   const diagnostic: LSP.Diagnostic = {
     range: TreeSitterUtil.range(node),
     severity: severity,

--- a/src/server/metaModelicaParser.ts
+++ b/src/server/metaModelicaParser.ts
@@ -49,7 +49,7 @@ import * as path from 'path';
  * @returns tree-sitter-metamodelica parser
  */
 export async function initializeMetaModelicaParser(): Promise<Parser> {
-  await Parser.init({ locateFile: () => path.join(__dirname, 'web-tree-sitter.wasm') });
+  await Parser.init();
   const parser = new Parser;
 
   const metamodelicaWasmFile = path.join(__dirname, 'tree-sitter-metamodelica.wasm');

--- a/src/server/metaModelicaParser.ts
+++ b/src/server/metaModelicaParser.ts
@@ -39,7 +39,7 @@
  * -----------------------------------------------------------------------------
  */
 
-import Parser from 'web-tree-sitter';
+import { Parser, Language } from 'web-tree-sitter';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -49,7 +49,7 @@ import * as path from 'path';
  * @returns tree-sitter-metamodelica parser
  */
 export async function initializeMetaModelicaParser(): Promise<Parser> {
-  await Parser.init();
+  await Parser.init({ locateFile: () => path.join(__dirname, 'web-tree-sitter.wasm') });
   const parser = new Parser;
 
   const metamodelicaWasmFile = path.join(__dirname, 'tree-sitter-metamodelica.wasm');
@@ -57,7 +57,7 @@ export async function initializeMetaModelicaParser(): Promise<Parser> {
     throw new Error(`Can't find 'tree-sitter-metamodelica.wasm' at ${metamodelicaWasmFile}`);
   }
 
-  const metaModelica = await Parser.Language.load(metamodelicaWasmFile);
+  const metaModelica = await Language.load(metamodelicaWasmFile);
   parser.setLanguage(metaModelica);
 
   return parser;

--- a/src/server/tree-sitter.ts
+++ b/src/server/tree-sitter.ts
@@ -40,7 +40,7 @@
  */
 
 import * as LSP from 'vscode-languageserver/node';
-import { SyntaxNode } from 'web-tree-sitter';
+import { Node as SyntaxNode } from 'web-tree-sitter';
 
 /**
  * Recursively iterate over all nodes in a tree.
@@ -67,7 +67,6 @@ export function findFirst(start: SyntaxNode, callback: (n: SyntaxNode) => boolea
 
   const cursor = start.walk();
   let reachedRoot = false;
-  let retracing = false;
 
   while (!reachedRoot) {
     const node = cursor.currentNode;
@@ -83,16 +82,14 @@ export function findFirst(start: SyntaxNode, callback: (n: SyntaxNode) => boolea
       continue;
     }
 
-    retracing = true;
-    while (retracing) {
-        if (!cursor.gotoParent()) {
-            retracing = false;
-            reachedRoot = true;
-        }
-
-        if (cursor.gotoNextSibling()) {
-        retracing = false;
-        }
+    while (true) {
+      if (!cursor.gotoParent()) {
+        reachedRoot = true;
+        break;
+      }
+      if (cursor.gotoNextSibling()) {
+        break;
+      }
     }
   }
 

--- a/test/debugger/gdbAdapter.test.ts
+++ b/test/debugger/gdbAdapter.test.ts
@@ -101,7 +101,7 @@ suite('GDBAdapter', () => {
     await adapter.quit();
     const response = adapter.getProgramOutput();
     // Check version string is in response.
-    assert.ok(response.startsWith("OpenModelica"), "Response should start with 'OpenModelica'");
+    assert.ok(response.startsWith("OpenModelica") || response.startsWith("v1."), "Response should start with 'OpenModelica' or 'v1.'");
     assert.equal(adapter.isGDBRunning(), false, "Assert GDB is not running any more.");
   }).timeout("10s");
 

--- a/test/server/declarations.test.ts
+++ b/test/server/declarations.test.ts
@@ -102,8 +102,8 @@ const expectedSymbols = [
 suite('nodeToDocumentSymbol', () => {
   test('type to TypeParameter', async () => {
   const parser = await initializeMetaModelicaParser();
-  const tree = parser.parse("type Temperature = Real(unit = \"K \");");
-  const queries = new MetaModelicaQueries(parser.getLanguage());
+  const tree = parser.parse("type Temperature = Real(unit = \"K \");")!;
+  const queries = new MetaModelicaQueries(parser.language!);
   const symbol = nodeToDocumentSymbol(tree.rootNode.childForFieldName("classDefinitionList")!, queries, []);
 
   assert.equal(symbol?.name, 'Temperature');
@@ -114,8 +114,8 @@ suite('nodeToDocumentSymbol', () => {
 suite('getAllDeclarationsInTree', () => {
   test('Definitions and types', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(metaModelicaTestString);
-    const queries = new MetaModelicaQueries(parser.getLanguage());
+    const tree = parser.parse(metaModelicaTestString)!;
+    const queries = new MetaModelicaQueries(parser.language!);
     const symbols = getAllDeclarationsInTree(tree, queries);
 
     assert.deepEqual(symbols, expectedSymbols);

--- a/test/server/diagnostics.test.ts
+++ b/test/server/diagnostics.test.ts
@@ -217,8 +217,8 @@ end foo;
 suite('getAllDeclarationsInTree', () => {
   test('Definitions and types', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(metaModelicaTestString);
-    const queries = new MetaModelicaQueries(parser.getLanguage());
+    const tree = parser.parse(metaModelicaTestString)!;
+    const queries = new MetaModelicaQueries(parser.language!);
     const diagnostics = getDiagnosticsFromTree(tree, queries);
 
     assert.deepEqual(diagnostics, expectedDiagnostics);
@@ -226,8 +226,8 @@ suite('getAllDeclarationsInTree', () => {
 
   test('Detects unused match argument', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(unusedMatchArgString);
-    const queries = new MetaModelicaQueries(parser.getLanguage());
+    const tree = parser.parse(unusedMatchArgString)!;
+    const queries = new MetaModelicaQueries(parser.language!);
     const diagnostics = getDiagnosticsFromTree(tree, queries);
 
     const unused = diagnostics.filter(d => d.message.startsWith('Unused match argument'));
@@ -249,8 +249,8 @@ suite('getAllDeclarationsInTree', () => {
 
   test('Does not report when all match arguments are used', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(usedMatchArgString);
-    const queries = new MetaModelicaQueries(parser.getLanguage());
+    const tree = parser.parse(usedMatchArgString)!;
+    const queries = new MetaModelicaQueries(parser.language!);
     const diagnostics = getDiagnosticsFromTree(tree, queries);
 
     const unused = diagnostics.filter(d => d.message.startsWith('Unused match argument'));
@@ -286,8 +286,8 @@ end addOne;
 
   test('Detects unused protected variable', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(unusedProtectedVarString);
-    const queries = new MetaModelicaQueries(parser.getLanguage());
+    const tree = parser.parse(unusedProtectedVarString)!;
+    const queries = new MetaModelicaQueries(parser.language!);
     const diagnostics = getDiagnosticsFromTree(tree, queries);
 
     const unused = diagnostics.filter(d => d.message.startsWith('Unused variable'));
@@ -305,8 +305,8 @@ end addOne;
 
   test('Does not report used protected variables', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(usedProtectedVarString);
-    const queries = new MetaModelicaQueries(parser.getLanguage());
+    const tree = parser.parse(usedProtectedVarString)!;
+    const queries = new MetaModelicaQueries(parser.language!);
     const diagnostics = getDiagnosticsFromTree(tree, queries);
 
     const unused = diagnostics.filter(d => d.message.startsWith('Unused variable'));
@@ -346,8 +346,8 @@ end foo;
 
   test('Detects unused local variable in match', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(unusedLocalVarString);
-    const queries = new MetaModelicaQueries(parser.getLanguage());
+    const tree = parser.parse(unusedLocalVarString)!;
+    const queries = new MetaModelicaQueries(parser.language!);
     const diagnostics = getDiagnosticsFromTree(tree, queries);
 
     const unused = diagnostics.filter(d => d.message.startsWith('Unused variable'));
@@ -362,8 +362,8 @@ end foo;
 
   test('Detects unused variable in comma-separated local declaration', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(unusedLocalMultiDeclString);
-    const queries = new MetaModelicaQueries(parser.getLanguage());
+    const tree = parser.parse(unusedLocalMultiDeclString)!;
+    const queries = new MetaModelicaQueries(parser.language!);
     const diagnostics = getDiagnosticsFromTree(tree, queries);
 
     const unused = diagnostics.filter(d => d.message.startsWith('Unused variable'));
@@ -379,8 +379,8 @@ end foo;
 
   test('Does not flag function-call arguments (only plain identifiers)', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(complexArgMatchString);
-    const queries = new MetaModelicaQueries(parser.getLanguage());
+    const tree = parser.parse(complexArgMatchString)!;
+    const queries = new MetaModelicaQueries(parser.language!);
     const diagnostics = getDiagnosticsFromTree(tree, queries);
 
     const unused = diagnostics.filter(d => d.message.startsWith('Unused match argument'));
@@ -421,8 +421,8 @@ end addOne;
 
   test('Detects silenced output (_ := expr)', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(silencedOutputString);
-    const queries = new MetaModelicaQueries(parser.getLanguage());
+    const tree = parser.parse(silencedOutputString)!;
+    const queries = new MetaModelicaQueries(parser.language!);
     const diagnostics = getDiagnosticsFromTree(tree, queries);
 
     const silenced = diagnostics.filter(d => d.message.startsWith('Unnecessary output silencing'));
@@ -445,8 +445,8 @@ end addOne;
 
   test('Does not flag regular assignments', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(noSilencedOutputString);
-    const queries = new MetaModelicaQueries(parser.getLanguage());
+    const tree = parser.parse(noSilencedOutputString)!;
+    const queries = new MetaModelicaQueries(parser.language!);
     const diagnostics = getDiagnosticsFromTree(tree, queries);
 
     const silenced = diagnostics.filter(d => d.message.startsWith('Unnecessary output silencing'));

--- a/test/server/server.test.ts
+++ b/test/server/server.test.ts
@@ -53,16 +53,16 @@ suite('MetaModelica tree-sitter parser', () => {
 
   test('Parse string', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(metaModelicaTestString);
+    const tree = parser.parse(metaModelicaTestString)!;
     const parsedString = tree.rootNode.toString();
     assert.equal(parsedString, parsedMetaModelicaTestString);
   });
 
   test('Identifier of type class', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse("type Temperature = Real(unit = \"K \");");
+    const tree = parser.parse("type Temperature = Real(unit = \"K \");")!;
     const classNode = tree.rootNode.childForFieldName("classDefinitionList")!;
-    const queries = new MetaModelicaQueries(parser.getLanguage());
+    const queries = new MetaModelicaQueries(parser.language!);
     const name = queries.getIdentifier(classNode);
     assert.equal(name, 'Temperature');
   });


### PR DESCRIPTION
## Changes

- Remove native \`tree-sitter\` (unused; fails to build on Node.js v24)
- Add missing ESLint 10 peer deps: \`globals\`, \`@eslint/js\`, \`@eslint/eslintrc\`

### web-tree-sitter v0.26 API migration

- Switch from default import to named imports (\`Parser\`, \`Language\`, \`Query\`, …)
- Rename \`SyntaxNode\` → \`Node\` (aliased to avoid churn)
- Replace \`language.query(s)\` with \`new Query(language, s)\`
- Replace \`parser.getLanguage()\` with \`parser.language!\` (now a property)
- Add \`!\` assertions for \`parser.parse()\` returning \`Tree | null\`
- Replace \`match.pattern\` with \`match.patternIndex\`
- Copy \`web-tree-sitter.wasm\` (renamed from \`tree-sitter.wasm\` in v0.26)
- Externalize \`web-tree-sitter\` in esbuild to avoid ESM/CJS bundling crash
  (\`createRequire(undefined)\` when \`import.meta.url\` is undefined in CJS bundle)

### Build / CI fixes

- Drop \`--docker\` flag from tree-sitter WASM build (removed in tree-sitter-cli v0.26);
  switch to \`tree-sitter build --wasm --output\` which works without Docker or emscripten
- Remove \`locateFile\` from \`Parser.init()\` — CJS module resolves WASM via its own \`__dirname\`

### Test fixes

- Add \`await\` to \`client.start()\` in \`activate()\` so the language server is ready before tests run
- Accept both \`OpenModelica\` and \`v1.\` prefixes in GDB version assertion (dev builds output \`v1.x.x\`)

### Security fixes

- Downgrade mocha \`^11.7.6\` → \`^11.3.0\` (bundles \`diff@5.x\`, outside vuln range)
- Add \`overrides\` to force \`serialize-javascript@^7.0.5\` (fixes RCE/DoS)

### Lint fixes

- Remove unused \`metaModelicaDebugger\` variable and dead code in \`extension.ts\`
- Refactor \`findFirst\` retracing loop to \`while (true)/break\`

### README

- Remove Docker from build dependencies; add Node.js >= 22 requirement
- Add Testing section with prerequisites and \`xvfb-run\` instructions for headless machines
- Update VSIX version references to v0.3.0