### PR TITLE
[Build] Bundle web-tree-sitter into server and CLI outputs

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,6 +1,13 @@
 const esbuild = require('esbuild');
 const fs = require('fs');
 
+// web-tree-sitter publishes both ESM (.js) and CJS (.cjs) builds.  esbuild
+// picks the ESM version by default; that build uses import.meta.url which
+// esbuild shims as undefined in CJS output, causing createRequire(undefined)
+// to throw at runtime.  Force the CJS variant so __dirname is used instead.
+// require.resolve() applies the "require" export condition and returns .cjs.
+const webTreeSitterCjs = require.resolve('web-tree-sitter');
+
 const production = process.argv.includes('--production');
 const watch = process.argv.includes('--watch');
 const watchStr = watch ? ' watch ' : ' ';
@@ -40,7 +47,8 @@ async function main() {
     sourcesContent: false,
     platform: 'node',
     outfile: './out/server.js',
-    external: ['vscode', 'web-tree-sitter'],
+    external: ['vscode'],
+    alias: { 'web-tree-sitter': webTreeSitterCjs },
     logLevel: 'warning',
     plugins: [
       /* add to the end of plugins array */
@@ -64,7 +72,8 @@ async function main() {
     sourcesContent: false,
     platform: 'node',
     outfile: './out/cli.js',
-    external: ['vscode', 'web-tree-sitter'],
+    external: ['vscode'],
+    alias: { 'web-tree-sitter': webTreeSitterCjs },
     banner: { js: '#!/usr/bin/env node' },
     logLevel: 'warning',
     plugins: [

--- a/test/server/bundle.test.ts
+++ b/test/server/bundle.test.ts
@@ -1,0 +1,66 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Tests run from dist/test/server/ — project root is three levels up.
+const projectRoot = path.resolve(__dirname, '../../..');
+
+suite('Bundle packaging', () => {
+  test('out/server.js does not externally require web-tree-sitter', () => {
+    const bundlePath = path.join(projectRoot, 'out', 'server.js');
+    assert.ok(fs.existsSync(bundlePath), `Bundle not found: ${bundlePath}`);
+    const bundle = fs.readFileSync(bundlePath, 'utf8');
+    // If web-tree-sitter is marked external in esbuild, the bundle contains a
+    // bare require("web-tree-sitter") that fails at runtime in an installed
+    // extension because node_modules is not shipped.
+    assert.ok(
+      !bundle.includes('require("web-tree-sitter")'),
+      'out/server.js contains require("web-tree-sitter") — web-tree-sitter must be bundled, not external'
+    );
+  });
+
+  test('out/cli.js does not externally require web-tree-sitter', () => {
+    const bundlePath = path.join(projectRoot, 'out', 'cli.js');
+    assert.ok(fs.existsSync(bundlePath), `Bundle not found: ${bundlePath}`);
+    const bundle = fs.readFileSync(bundlePath, 'utf8');
+    assert.ok(
+      !bundle.includes('require("web-tree-sitter")'),
+      'out/cli.js contains require("web-tree-sitter") — web-tree-sitter must be bundled, not external'
+    );
+  });
+});


### PR DESCRIPTION
## Issue

The extension crashes on startup in VS Code.

## Changes

- Remove 'web-tree-sitter' from esbuild external list so it is included in out/server.js and out/cli.js instead of requiring node_modules at runtime (which is absent in installed .vsix extensions)
- Add alias to force esbuild to pick web-tree-sitter.cjs over the ESM build; the ESM build uses import.meta.url which esbuild shims as undefined in CJS output, causing createRequire(undefined) to throw during server initialisation
- Add test/server/bundle.test.ts to assert neither bundle contains a bare require("web-tree-sitter"), catching regressions at test time