### PR TITLE
[Server] Don't flag `_ := match` as unnecessary output silencing

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ building), the tool is available as `mmlsc`.
 | `unused-var` | Unused variable in a `protected` section or `local` block | Remove the variable declaration |
 | `unused-match-arg` | Unused `match`/`matchcontinue` argument (pattern is `_` in every case) | Remove the argument from the input tuple and all case patterns |
 | `unused-silenced-output` | Unnecessary output silencing (`_ := expr`) — the `_ :=` prefix can be omitted | Remove the `_ :=` prefix, keeping only the expression |
+| `wildcard-match` | Wildcard before `match`/`matchcontinue` (`_ := match …`) — `_` silently discards any return value; `()` is preferred because the compiler will error if a branch returns a non-unit value, catching accidental discards | Replace `_` with `()` |
 
 ## Installation
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -42,9 +42,9 @@ import { initializeMetaModelicaParser } from '../server/metaModelicaParser';
 import Analyzer from '../server/analyzer';
 import { UnusedArgFix, UnusedVarFix, SilencedOutputFix, WildcardMatchFix } from '../server/diagnostics';
 
-export type CheckName = 'unused-var' | 'unused-match-arg' | 'unused-silenced-output';
+export type CheckName = 'unused-var' | 'unused-match-arg' | 'unused-silenced-output' | 'wildcard-match';
 
-export const ALL_CHECKS: CheckName[] = ['unused-var', 'unused-match-arg', 'unused-silenced-output'];
+export const ALL_CHECKS: CheckName[] = ['unused-var', 'unused-match-arg', 'unused-silenced-output', 'wildcard-match'];
 
 export interface ProcessResult {
   filesProcessed: number;
@@ -99,7 +99,7 @@ function getFixEdits(
   if (checks.has('unused-match-arg') && data.unusedArgFix) { return data.unusedArgFix.edits; }
   if (checks.has('unused-var') && data.unusedVarFix) { return data.unusedVarFix.edits; }
   if (checks.has('unused-silenced-output') && data.silencedOutputFix) { return data.silencedOutputFix.edits; }
-  if (checks.has('unused-silenced-output') && data.wildcardMatchFix) { return data.wildcardMatchFix.edits; }
+  if (checks.has('wildcard-match') && data.wildcardMatchFix) { return data.wildcardMatchFix.edits; }
   return undefined;
 }
 
@@ -192,7 +192,8 @@ async function main(): Promise<void> {
       '  Available check names:\n' +
       '    unused-var              Unused protected/local variables\n' +
       '    unused-match-arg        Unused match/matchcontinue arguments\n' +
-      '    unused-silenced-output  Unnecessary output silencing (\'_ := expr\')\n\n' +
+      '    unused-silenced-output  Unnecessary output silencing (\'_ := expr\')\n' +
+      '    wildcard-match          Wildcard before match/matchcontinue (\'_ :=\' → \'() :=\')\n\n' +
       '  paths    Files or directories to process (.mo files, directories are scanned recursively)'
     );
     process.exit(0);

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -40,7 +40,7 @@ import * as LSP from 'vscode-languageserver/node';
 
 import { initializeMetaModelicaParser } from '../server/metaModelicaParser';
 import Analyzer from '../server/analyzer';
-import { UnusedArgFix, UnusedVarFix, SilencedOutputFix } from '../server/diagnostics';
+import { UnusedArgFix, UnusedVarFix, SilencedOutputFix, WildcardMatchFix } from '../server/diagnostics';
 
 export type CheckName = 'unused-var' | 'unused-match-arg' | 'unused-silenced-output';
 
@@ -92,13 +92,14 @@ function applyEdits(content: string, uri: string, edits: LSP.TextEdit[]): string
  * checks, or undefined if it should be skipped.
  */
 function getFixEdits(
-  data: { unusedArgFix?: UnusedArgFix; unusedVarFix?: UnusedVarFix; silencedOutputFix?: SilencedOutputFix } | undefined,
+  data: { unusedArgFix?: UnusedArgFix; unusedVarFix?: UnusedVarFix; silencedOutputFix?: SilencedOutputFix; wildcardMatchFix?: WildcardMatchFix } | undefined,
   checks: Set<CheckName>,
 ): LSP.TextEdit[] | undefined {
   if (!data) { return undefined; }
   if (checks.has('unused-match-arg') && data.unusedArgFix) { return data.unusedArgFix.edits; }
   if (checks.has('unused-var') && data.unusedVarFix) { return data.unusedVarFix.edits; }
   if (checks.has('unused-silenced-output') && data.silencedOutputFix) { return data.silencedOutputFix.edits; }
+  if (checks.has('unused-silenced-output') && data.wildcardMatchFix) { return data.wildcardMatchFix.edits; }
   return undefined;
 }
 
@@ -141,7 +142,7 @@ export async function processFiles(
         const doc = TextDocument.create(uri, 'metamodelica', 1, content);
         const diagnostics = analyzer.analyze(doc);
         for (const diagnostic of diagnostics) {
-          const data = diagnostic.data as { unusedArgFix?: UnusedArgFix; unusedVarFix?: UnusedVarFix; silencedOutputFix?: SilencedOutputFix } | undefined;
+          const data = diagnostic.data as { unusedArgFix?: UnusedArgFix; unusedVarFix?: UnusedVarFix; silencedOutputFix?: SilencedOutputFix; wildcardMatchFix?: WildcardMatchFix } | undefined;
           const edits = getFixEdits(data, checks);
           if (edits) {
             content = applyEdits(content, uri, edits);
@@ -161,7 +162,7 @@ export async function processFiles(
       const diagnostics = analyzer.analyze(doc);
       let count = 0;
       for (const diagnostic of diagnostics) {
-        const data = diagnostic.data as { unusedArgFix?: UnusedArgFix; unusedVarFix?: UnusedVarFix; silencedOutputFix?: SilencedOutputFix } | undefined;
+        const data = diagnostic.data as { unusedArgFix?: UnusedArgFix; unusedVarFix?: UnusedVarFix; silencedOutputFix?: SilencedOutputFix; wildcardMatchFix?: WildcardMatchFix } | undefined;
         if (getFixEdits(data, checks)) {
           const { line, character } = diagnostic.range.start;
           console.log(`${filePath}:${line + 1}:${character + 1}: ${diagnostic.message}`);

--- a/src/server/diagnostics.ts
+++ b/src/server/diagnostics.ts
@@ -521,7 +521,7 @@ export function getDiagnosticsFromTree(tree: Parser.Tree, queries: MetaModelicaQ
     const diagnostic = nodeToDiagnostic(
       wildNode,
       LSP.DiagnosticSeverity.Information,
-      `Replace '_ :=' with '() :=' before match/matchcontinue to make explicit that output is discarded.`);
+      `Replace '_ :=' with '() :=' before match/matchcontinue to ensure output of match/matchcontinue isn't ignored by accident.`);
     (diagnostic as LSP.Diagnostic & { data: unknown }).data = { wildcardMatchFix: fix };
     diagnostics.push(diagnostic);
   }

--- a/src/server/diagnostics.ts
+++ b/src/server/diagnostics.ts
@@ -54,6 +54,10 @@ export interface SilencedOutputFix {
   edits: LSP.TextEdit[];
 }
 
+export interface WildcardMatchFix {
+  edits: LSP.TextEdit[];
+}
+
 /**
  * Extract tuple element expressions from a `(a, b, c)` expression node.
  * Returns null if the expression is not a parenthesized tuple with at least two elements.
@@ -339,12 +343,19 @@ function isWildcardSimpleExpr(simpleExpr: Parser.Node): boolean {
 }
 
 /**
- * Find `_ := expr` statements in algorithm sections.  The return value of the
- * called function is silenced unnecessarily — in MetaModelica the assignment
- * can simply be omitted.
+ * Find `_ := expr` statements in algorithm sections.
+ *
+ * Returns two kinds of results:
+ * - `silenced`: `_ := functionCall()` where `_ :=` can simply be removed.
+ * - `wildcardMatch`: `_ := match/matchcontinue` where `_` should be replaced
+ *   with `()` because match expressions cannot be used as standalone statements.
  */
-function getSilencedOutputs(rootNode: Parser.Node): { wildNode: Parser.Node; fix: SilencedOutputFix }[] {
-  const results: { wildNode: Parser.Node; fix: SilencedOutputFix }[] = [];
+function getSilencedOutputs(rootNode: Parser.Node): {
+  silenced: { wildNode: Parser.Node; fix: SilencedOutputFix }[];
+  wildcardMatch: { wildNode: Parser.Node; fix: WildcardMatchFix }[];
+} {
+  const silenced: { wildNode: Parser.Node; fix: SilencedOutputFix }[] = [];
+  const wildcardMatch: { wildNode: Parser.Node; fix: WildcardMatchFix }[] = [];
 
   TreeSitterUtil.forEach(rootNode, (node) => {
     if (node.type !== 'assign_clause_a') { return true; }
@@ -358,22 +369,42 @@ function getSilencedOutputs(rootNode: Parser.Node): { wildNode: Parser.Node; fix
     // The WILD node is nested inside lhsExpr.
     const wildNode = lhsExpr.namedChildren[0].namedChildren[0].namedChildren[0];
 
-    // Remove `_ := ` by replacing the span from the start of assign_clause_a
-    // to the start of the RHS expression with an empty string.
-    const fix: SilencedOutputFix = {
-      edits: [{
-        range: LSP.Range.create(
-          node.startPosition.row, node.startPosition.column,
-          rhsExpr.startPosition.row, rhsExpr.startPosition.column,
-        ),
-        newText: '',
-      }],
-    };
-    results.push({ wildNode, fix });
+    if (rhsExpr.namedChildren.some(c => c.type === 'match_expression')) {
+      // `_ := match/matchcontinue` — match expressions cannot be used as
+      // standalone statements, so `_ :=` is required. Replace `_` with `()`
+      // to make it explicit that the output is intentionally discarded.
+      wildcardMatch.push({
+        wildNode,
+        fix: {
+          edits: [{
+            range: LSP.Range.create(
+              wildNode.startPosition.row, wildNode.startPosition.column,
+              wildNode.endPosition.row, wildNode.endPosition.column,
+            ),
+            newText: '()',
+          }],
+        },
+      });
+    } else {
+      // Remove `_ := ` by replacing the span from the start of assign_clause_a
+      // to the start of the RHS expression with an empty string.
+      silenced.push({
+        wildNode,
+        fix: {
+          edits: [{
+            range: LSP.Range.create(
+              node.startPosition.row, node.startPosition.column,
+              rhsExpr.startPosition.row, rhsExpr.startPosition.column,
+            ),
+            newText: '',
+          }],
+        },
+      });
+    }
     return true;
   });
 
-  return results;
+  return { silenced, wildcardMatch };
 }
 
 export function getDiagnosticsFromTree(tree: Parser.Tree, queries: MetaModelicaQueries): LSP.Diagnostic[] {
@@ -477,13 +508,21 @@ export function getDiagnosticsFromTree(tree: Parser.Tree, queries: MetaModelicaQ
   }
 
   // Inform about silenced outputs (`_ := expr`)
-  const silencedOutputs = getSilencedOutputs(tree.rootNode);
+  const { silenced: silencedOutputs, wildcardMatch: wildcardMatches } = getSilencedOutputs(tree.rootNode);
   for (const { wildNode, fix } of silencedOutputs) {
     const diagnostic = nodeToDiagnostic(
       wildNode,
       LSP.DiagnosticSeverity.Information,
       `Unnecessary output silencing: replace '_ := expr' with just 'expr'.`);
     (diagnostic as LSP.Diagnostic & { data: unknown }).data = { silencedOutputFix: fix };
+    diagnostics.push(diagnostic);
+  }
+  for (const { wildNode, fix } of wildcardMatches) {
+    const diagnostic = nodeToDiagnostic(
+      wildNode,
+      LSP.DiagnosticSeverity.Information,
+      `Replace '_ :=' with '() :=' before match/matchcontinue to make explicit that output is discarded.`);
+    (diagnostic as LSP.Diagnostic & { data: unknown }).data = { wildcardMatchFix: fix };
     diagnostics.push(diagnostic);
   }
 

--- a/src/server/extension.ts
+++ b/src/server/extension.ts
@@ -45,7 +45,7 @@ import { TextDocument} from 'vscode-languageserver-textdocument';
 import { initializeMetaModelicaParser } from './metaModelicaParser';
 import Analyzer from './analyzer';
 import { logger, setLogConnection, setLogLevel } from '../util/logger';
-import { UnusedArgFix, UnusedVarFix, SilencedOutputFix } from './diagnostics';
+import { UnusedArgFix, UnusedVarFix, SilencedOutputFix, WildcardMatchFix } from './diagnostics';
 
 /**
  * MetaModelicaServer collection all the important bits and bobs.
@@ -153,7 +153,7 @@ export class MetaModelicaServer {
   private onCodeAction(params: LSP.CodeActionParams): LSP.CodeAction[] {
     const actions: LSP.CodeAction[] = [];
     for (const diagnostic of params.context.diagnostics) {
-      const data = diagnostic.data as { unusedArgFix?: UnusedArgFix; unusedVarFix?: UnusedVarFix; silencedOutputFix?: SilencedOutputFix } | undefined;
+      const data = diagnostic.data as { unusedArgFix?: UnusedArgFix; unusedVarFix?: UnusedVarFix; silencedOutputFix?: SilencedOutputFix; wildcardMatchFix?: WildcardMatchFix } | undefined;
       if (data?.unusedArgFix) {
         const fix = data.unusedArgFix;
         actions.push({
@@ -186,6 +186,20 @@ export class MetaModelicaServer {
         const fix = data.silencedOutputFix;
         actions.push({
           title: `Remove unnecessary '_ :='`,
+          kind: LSP.CodeActionKind.QuickFix,
+          diagnostics: [diagnostic],
+          isPreferred: true,
+          edit: {
+            changes: {
+              [params.textDocument.uri]: fix.edits
+            }
+          }
+        });
+      }
+      if (data?.wildcardMatchFix) {
+        const fix = data.wildcardMatchFix;
+        actions.push({
+          title: `Replace '_ :=' with '() :='`,
           kind: LSP.CodeActionKind.QuickFix,
           diagnostics: [diagnostic],
           isPreferred: true,

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -317,4 +317,67 @@ end binTreeintersection1;
 
     assert.strictEqual(result.issuesFound, 0, 'Silenced output should not be reported under unused-var');
   });
+
+  // ── wildcard-match ─────────────────────────────────────────────────────────
+
+  const wildcardMatchSource = `function testMatch
+  input Integer x;
+algorithm
+  _ := match (x)
+    case 1 then ();
+    else ();
+  end match;
+end testMatch;
+`;
+
+  const wildcardMatchFixed = `function testMatch
+  input Integer x;
+algorithm
+  () := match (x)
+    case 1 then ();
+    else ();
+  end match;
+end testMatch;
+`;
+
+  test('detects wildcard-match (report mode)', async () => {
+    const filePath = path.join(tmpDir, 'wildcard.mo');
+    fs.writeFileSync(filePath, wildcardMatchSource);
+
+    const result = await processFiles([filePath], false);
+
+    assert.strictEqual(result.filesProcessed, 1);
+    assert.strictEqual(result.issuesFound, 1);
+    assert.strictEqual(result.issuesFixed, 0);
+    assert.strictEqual(fs.readFileSync(filePath, 'utf-8'), wildcardMatchSource);
+  });
+
+  test('fixes wildcard-match in-place (fix mode)', async () => {
+    const filePath = path.join(tmpDir, 'wildcard.mo');
+    fs.writeFileSync(filePath, wildcardMatchSource);
+
+    const result = await processFiles([filePath], true);
+
+    assert.strictEqual(result.filesProcessed, 1);
+    assert.strictEqual(result.issuesFixed, 1);
+    assert.strictEqual(fs.readFileSync(filePath, 'utf-8'), wildcardMatchFixed);
+  });
+
+  test('--check wildcard-match reports only wildcard-match issues', async () => {
+    const filePath = path.join(tmpDir, 'wildcard.mo');
+    fs.writeFileSync(filePath, wildcardMatchSource);
+
+    const result = await processFiles([filePath], false, new Set(['wildcard-match']));
+
+    assert.strictEqual(result.issuesFound, 1, 'Wildcard-match issue should be reported');
+  });
+
+  test('--check unused-silenced-output does not report wildcard-match', async () => {
+    const filePath = path.join(tmpDir, 'wildcard.mo');
+    fs.writeFileSync(filePath, wildcardMatchSource);
+
+    const result = await processFiles([filePath], false, new Set(['unused-silenced-output']));
+
+    assert.strictEqual(result.issuesFound, 0, 'Wildcard-match should not be reported under unused-silenced-output');
+  });
 });

--- a/test/server/diagnostics.test.ts
+++ b/test/server/diagnostics.test.ts
@@ -452,4 +452,69 @@ end addOne;
     const silenced = diagnostics.filter(d => d.message.startsWith('Unnecessary output silencing'));
     assert.strictEqual(silenced.length, 0);
   });
+
+  const silencedMatchString = `
+function testMatch
+  input Integer x;
+algorithm
+  _ := match (x)
+    case 1 then ();
+    else ();
+  end match;
+end testMatch;
+`;
+
+  const silencedMatchContinueString = `
+function testMatchContinue
+  input Integer x;
+algorithm
+  _ := matchcontinue (x)
+    case 1 then ();
+    else ();
+  end matchcontinue;
+end testMatchContinue;
+`;
+
+  test('Flags _ := match with wildcard-match diagnostic and () fix', async () => {
+    const parser = await initializeMetaModelicaParser();
+    const tree = parser.parse(silencedMatchString)!;
+    const queries = new MetaModelicaQueries(parser.language!);
+    const diagnostics = getDiagnosticsFromTree(tree, queries);
+
+    const silenced = diagnostics.filter(d => d.message.startsWith('Unnecessary output silencing'));
+    assert.strictEqual(silenced.length, 0, 'must not emit silenced-output diagnostic for match');
+
+    const wildcard = diagnostics.filter(d => d.message.startsWith("Replace '_ :=' with '() :='"));
+    assert.strictEqual(wildcard.length, 1, 'exactly one wildcard-match diagnostic expected');
+
+    const d = wildcard[0] as LSP.Diagnostic & { data: { wildcardMatchFix: { edits: LSP.TextEdit[] } } };
+    assert.strictEqual(d.severity, LSP.DiagnosticSeverity.Information);
+    // Diagnostic points at the `_` token (line 4, column 2)
+    assert.deepEqual(d.range.start, { line: 4, character: 2 });
+    assert.deepEqual(d.range.end, { line: 4, character: 3 });
+    // Fix replaces just `_` with `()`
+    assert.strictEqual(d.data.wildcardMatchFix.edits.length, 1);
+    assert.strictEqual(d.data.wildcardMatchFix.edits[0].newText, '()');
+    assert.deepEqual(d.data.wildcardMatchFix.edits[0].range.start, { line: 4, character: 2 });
+    assert.deepEqual(d.data.wildcardMatchFix.edits[0].range.end, { line: 4, character: 3 });
+  });
+
+  test('Flags _ := matchcontinue with wildcard-match diagnostic and () fix', async () => {
+    const parser = await initializeMetaModelicaParser();
+    const tree = parser.parse(silencedMatchContinueString)!;
+    const queries = new MetaModelicaQueries(parser.language!);
+    const diagnostics = getDiagnosticsFromTree(tree, queries);
+
+    const silenced = diagnostics.filter(d => d.message.startsWith('Unnecessary output silencing'));
+    assert.strictEqual(silenced.length, 0, 'must not emit silenced-output diagnostic for matchcontinue');
+
+    const wildcard = diagnostics.filter(d => d.message.startsWith("Replace '_ :=' with '() :='"));
+    assert.strictEqual(wildcard.length, 1, 'exactly one wildcard-match diagnostic expected');
+
+    const d = wildcard[0] as LSP.Diagnostic & { data: { wildcardMatchFix: { edits: LSP.TextEdit[] } } };
+    assert.strictEqual(d.severity, LSP.DiagnosticSeverity.Information);
+    assert.deepEqual(d.range.start, { line: 4, character: 2 });
+    assert.deepEqual(d.range.end, { line: 4, character: 3 });
+    assert.strictEqual(d.data.wildcardMatchFix.edits[0].newText, '()');
+  });
 });


### PR DESCRIPTION
## Issue

Fixes #49

## Changes

`_ := match/matchcontinue` is legal MetaModelica — `match` expressions cannot be used as standalone statements, so the `_ :=` prefix is required. However, using `_` silently discards any return value from a branch; `()` is preferred because the compiler will error if a branch returns a non-unit value, catching accidental discards.

* Add a new `wildcardMatch` diagnostic for `_ := match/matchcontinue` that suggests replacing `_` with `()` rather than removing `_ :=` entirely
* Add a new wildcard-match CLI check name (separate from unused-silenced-output) so the two patterns can be targeted independently
* Update the README quick-fix table with the new check
* Add tests in both the server diagnostics suite and the CLI integration suite

