### PR TITLE
[Server] Don't flag outer-scope constants as unused case bindings

### DIFF
--- a/src/server/diagnostics.ts
+++ b/src/server/diagnostics.ts
@@ -915,6 +915,14 @@ function getUnusedCaseBindings(rootNode: Parser.Node):
     while (scope && scope.type !== 'class_definition') { scope = scope.parent; }
     const enclosing: Parser.Node = scope ?? rootNode;
 
+    // Find the immediately enclosing match_expression so we can distinguish
+    // its local-clause declarations (pattern variables) from outer-scope
+    // declarations (constants, function parameters, etc.).
+    let matchExprNode: Parser.Node | null = node.parent;
+    while (matchExprNode && matchExprNode.type !== 'match_expression') {
+      matchExprNode = matchExprNode.parent;
+    }
+
     const outsideNames = new Set<string>();
     const skipStart = node.startIndex;
     const skipEnd = node.endIndex;
@@ -930,6 +938,51 @@ function getUnusedCaseBindings(rootNode: Parser.Node):
     }
     collectOutside(enclosing);
 
+    // Collect names declared outside the match expression (e.g. package-level
+    // constants, function parameters, protected variables). An identifier in a
+    // case pattern that matches such a name is a value match against a known
+    // symbol — not a fresh binding — and must not be flagged as unused.
+    // We scan the entire file (rootNode) so that package-level constants
+    // defined outside the enclosing function are also found.
+    // Import statements (`import Pkg.NAME;` / `import ALIAS = Pkg.Name;`)
+    // bring names from other files into scope; those are also collected here.
+    const outerDeclaredNames = new Set<string>();
+    if (matchExprNode) {
+      const matchStart = matchExprNode.startIndex;
+      const matchEnd = matchExprNode.endIndex;
+      function collectOuterDeclared(n: Parser.Node): void {
+        // Skip the match expression itself: names declared in its local clause
+        // are match-local variables, not outer constants or function params.
+        if (n.startIndex === matchStart && n.endIndex === matchEnd) { return; }
+        if (n.type === 'IDENT' && n.parent?.type === 'declaration') {
+          outerDeclaredNames.add(n.text);
+        }
+        // `import Pkg.NAME;` — implicit import: the last IDENT in name_path_star
+        // is the name brought into scope.
+        // `import ALIAS = Pkg.Name;` — explicit import: the first IDENT (alias)
+        // is the name brought into scope.
+        if (n.type === 'import_clause') {
+          const implicit = n.namedChildren.find(c => c.type === 'implicit_import_name');
+          if (implicit) {
+            const namePath = implicit.namedChildren.find(c => c.type === 'name_path_star');
+            if (namePath) {
+              const identNodes = namePath.children.filter(c => c.type === 'IDENT');
+              const last = identNodes[identNodes.length - 1];
+              if (last) { outerDeclaredNames.add(last.text); }
+            }
+          }
+          const explicit = n.namedChildren.find(c => c.type === 'explicit_import_name');
+          if (explicit) {
+            const alias = explicit.children.find(c => c.type === 'IDENT');
+            if (alias) { outerDeclaredNames.add(alias.text); }
+          }
+          return; // no need to recurse into import_clause
+        }
+        for (const c of n.children) { collectOuterDeclared(c); }
+      }
+      collectOuterDeclared(rootNode);
+    }
+
     function visit(e: Parser.Node): void {
       if (e.type === 'expression') {
         const ident = getSimpleIdentifierLeaf(e);
@@ -937,7 +990,8 @@ function getUnusedCaseBindings(rootNode: Parser.Node):
           const name = ident.text;
           if (name !== '_'
               && (insideCounts.get(name) ?? 0) === 1
-              && !outsideNames.has(name)) {
+              && !outsideNames.has(name)
+              && !outerDeclaredNames.has(name)) {
             results.push({
               identNode: ident,
               fix: {

--- a/test/server/diagnostics.test.ts
+++ b/test/server/diagnostics.test.ts
@@ -217,7 +217,7 @@ end foo;
 suite('getAllDeclarationsInTree', () => {
   test('Definitions and types', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(metaModelicaTestString)!!!;
+    const tree = parser.parse(metaModelicaTestString)!;
     const queries = new MetaModelicaQueries(parser.language!);
     const diagnostics = getDiagnosticsFromTree(tree, queries)
       .filter(d => !d.message.startsWith('Redundant parentheses'));
@@ -227,7 +227,7 @@ suite('getAllDeclarationsInTree', () => {
 
   test('Detects unused match argument', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(unusedMatchArgString)!!!;
+    const tree = parser.parse(unusedMatchArgString)!;
     const queries = new MetaModelicaQueries(parser.language!);
     const diagnostics = getDiagnosticsFromTree(tree, queries);
 
@@ -250,7 +250,7 @@ suite('getAllDeclarationsInTree', () => {
 
   test('Does not report when all match arguments are used', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(usedMatchArgString)!!!;
+    const tree = parser.parse(usedMatchArgString)!;
     const queries = new MetaModelicaQueries(parser.language!);
     const diagnostics = getDiagnosticsFromTree(tree, queries);
 
@@ -287,7 +287,7 @@ end addOne;
 
   test('Detects unused protected variable', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(unusedProtectedVarString)!!!;
+    const tree = parser.parse(unusedProtectedVarString)!;
     const queries = new MetaModelicaQueries(parser.language!);
     const diagnostics = getDiagnosticsFromTree(tree, queries);
 
@@ -306,7 +306,7 @@ end addOne;
 
   test('Does not report used protected variables', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(usedProtectedVarString)!!!;
+    const tree = parser.parse(usedProtectedVarString)!;
     const queries = new MetaModelicaQueries(parser.language!);
     const diagnostics = getDiagnosticsFromTree(tree, queries);
 
@@ -347,7 +347,7 @@ end foo;
 
   test('Detects unused local variable in match', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(unusedLocalVarString)!!!;
+    const tree = parser.parse(unusedLocalVarString)!;
     const queries = new MetaModelicaQueries(parser.language!);
     const diagnostics = getDiagnosticsFromTree(tree, queries);
 
@@ -363,7 +363,7 @@ end foo;
 
   test('Detects unused variable in comma-separated local declaration', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(unusedLocalMultiDeclString)!!!;
+    const tree = parser.parse(unusedLocalMultiDeclString)!;
     const queries = new MetaModelicaQueries(parser.language!);
     const diagnostics = getDiagnosticsFromTree(tree, queries);
 
@@ -398,7 +398,7 @@ end foo;
 
   test('Detects unused case-pattern binding', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(unusedCaseBindingString)!!;
+    const tree = parser.parse(unusedCaseBindingString)!;
     const queries = new MetaModelicaQueries(parser.language!);
     const diagnostics = getDiagnosticsFromTree(tree, queries);
 
@@ -413,6 +413,66 @@ end foo;
     assert.strictEqual(d.data.unusedCaseBindingFix.bindName, 'i');
     assert.strictEqual(d.data.unusedCaseBindingFix.edits.length, 1);
     assert.strictEqual(d.data.unusedCaseBindingFix.edits[0].newText, '_');
+  });
+
+  const enumPatternString = `
+encapsulated package ClockIndexes
+  public constant Integer RT_NO_CLOCK = 0;
+  public constant Integer RT_CLOCK_TOTAL = 1;
+
+  function toString
+    input Integer clockIndex;
+    output String str;
+  algorithm
+    str := match clockIndex
+      case RT_NO_CLOCK  then "NON";
+      case RT_CLOCK_TOTAL then "TOT";
+      else "ERR";
+    end match;
+  end toString;
+end ClockIndexes;
+`;
+
+  test('Does not flag package-level constants used as case patterns', async () => {
+    const parser = await initializeMetaModelicaParser();
+    const tree = parser.parse(enumPatternString)!;
+    const queries = new MetaModelicaQueries(parser.language!);
+    const diagnostics = getDiagnosticsFromTree(tree, queries);
+
+    const unused = diagnostics.filter(d => d.message.startsWith('Unused case binding'));
+    assert.strictEqual(unused.length, 0,
+      'Constants used as case patterns must not be flagged as unused bindings');
+  });
+
+  const importedConstantPatternString = `
+package P
+  import ClockIndexes.RT_NO_CLOCK;
+  import ClockIndexes.RT_CLOCK_TOTAL;
+  import PROFILER = ClockIndexes.RT_PROFILER;
+
+  function toString
+    input Integer clockIndex;
+    output String str;
+  algorithm
+    str := match clockIndex
+      case RT_NO_CLOCK    then "NON";
+      case RT_CLOCK_TOTAL then "TOT";
+      case PROFILER       then "PRF";
+      else "ERR";
+    end match;
+  end toString;
+end P;
+`;
+
+  test('Does not flag imported names used as case patterns', async () => {
+    const parser = await initializeMetaModelicaParser();
+    const tree = parser.parse(importedConstantPatternString)!;
+    const queries = new MetaModelicaQueries(parser.language!);
+    const diagnostics = getDiagnosticsFromTree(tree, queries);
+
+    const unused = diagnostics.filter(d => d.message.startsWith('Unused case binding'));
+    assert.strictEqual(unused.length, 0,
+      'Imported names used as case patterns must not be flagged as unused bindings');
   });
 
   const multiProtectedSectionString = `
@@ -495,7 +555,7 @@ end foo;
 
   test('Does not flag function-call arguments (only plain identifiers)', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(complexArgMatchString)!!!;
+    const tree = parser.parse(complexArgMatchString)!;
     const queries = new MetaModelicaQueries(parser.language!);
     const diagnostics = getDiagnosticsFromTree(tree, queries);
 
@@ -537,7 +597,7 @@ end addOne;
 
   test('Detects silenced output (_ := expr)', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(silencedOutputString)!!!;
+    const tree = parser.parse(silencedOutputString)!;
     const queries = new MetaModelicaQueries(parser.language!);
     const diagnostics = getDiagnosticsFromTree(tree, queries);
 
@@ -561,7 +621,7 @@ end addOne;
 
   test('Does not flag regular assignments', async () => {
     const parser = await initializeMetaModelicaParser();
-    const tree = parser.parse(noSilencedOutputString)!!!;
+    const tree = parser.parse(noSilencedOutputString)!;
     const queries = new MetaModelicaQueries(parser.language!);
     const diagnostics = getDiagnosticsFromTree(tree, queries);
 


### PR DESCRIPTION
## Issue

Fixes #53.

## Changes

- Enumeration literals and package-level constants used in `case` patterns (e.g. `case RT_NO_CLOCK then "NON"`) were incorrectly offered an "unused binding → _" quick fix because the server had no type info to distinguish them from fresh binding variables.
- Fix: scan the whole file for names declared outside the enclosing `match_expression` (covers constants in the same package); also collect names introduced by `import Pkg.NAME;` and `import ALIAS = Pkg.Name;` statements so cross-file imports are handled too.
- Add regression tests for both cases.

